### PR TITLE
Remove the npm prepublish script

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
     "pretest": "npm run lint",
     "test": "karma start",
     "test-watch": "karma start --no-single-run --auto-watch",
-    "build": "ng-packagr -p ng-package.json",
-    "prepublish": "npm run build"
+    "build": "ng-packagr -p ng-package.json"
   },
   "devDependencies": {
     "@angular/common": "^5.2.1",


### PR DESCRIPTION
This PR removes the npm `prepublish` script, because it hinders npm from publishing the library.