### PR TITLE
Made step indicators clickable.

### DIFF
--- a/src/components/wizard-navigation-bar.component.horizontal.less
+++ b/src/components/wizard-navigation-bar.component.horizontal.less
@@ -120,12 +120,12 @@ aw-wizard-navigation-bar.horizontal {
           .line(@small-dot-width, @small-dot-height, @wz-color-default);
         }
 
-        & div a:before {
+        div a:before {
           .state-circle(@small-dot-width, @small-dot-height, 0);
           .state-circle-with-background(@wz-color-default);
         }
 
-        & div a:hover:before {
+        div a:hover:before {
           .state-circle-hover(@small-dot-width, @small-dot-height, 0);
           .state-circle-with-background-hover(@wz-color-default);
         }
@@ -155,12 +155,12 @@ aw-wizard-navigation-bar.horizontal {
           .line(@big-dot-width, @big-dot-height, @wz-color-default);
         }
 
-        & div a:before {
+        div a:before {
           .state-circle(@big-dot-width, @big-dot-height, 0);
           .state-circle-with-background(@wz-color-default);
         }
 
-        & div a:hover:before {
+        div a:hover:before {
           .state-circle-hover(@big-dot-width, @big-dot-height, 0);
           .state-circle-with-background-hover(@wz-color-default);
         }
@@ -190,12 +190,12 @@ aw-wizard-navigation-bar.horizontal {
           .line(@big-dot-width, @big-dot-height, @wz-color-default);
         }
 
-        & div a:before {
+        div a:before {
           .state-circle(@big-dot-width, @big-dot-height, @dot-border-width);
           .state-circle-with-border(@dot-border-width, @wz-color-default);
         }
 
-        & div a:hover:before {
+        div a:hover:before {
           .state-circle-hover(@big-dot-width, @big-dot-height, @dot-border-width);
           .state-circle-with-border-hover(@dot-border-width, @wz-color-default);
         }
@@ -225,16 +225,16 @@ aw-wizard-navigation-bar.horizontal {
           .line(@big-dot-width, @big-dot-height, @wz-color-default);
         }
 
-        & div a:before {
+        div a:before {
           .state-circle(@big-dot-width, @big-dot-height, 0);
           .state-circle-with-background-and-content(@wz-color-default);
-        }
-
-        & div a:hover:before {
-          .state-circle-hover(@big-dot-width, @big-dot-height, 0);
-          .state-circle-with-background-and-content-hover(@wz-color-default);
 
           content: attr(step-symbol);
+        }
+
+        div a:hover:before {
+          .state-circle-hover(@big-dot-width, @big-dot-height, 0);
+          .state-circle-with-background-and-content-hover(@wz-color-default);
         }
       }
 
@@ -262,16 +262,16 @@ aw-wizard-navigation-bar.horizontal {
           .line(@big-dot-width, @big-dot-height, @wz-color-default);
         }
 
-        & div a:before {
+        div a:before {
           .state-circle(@big-dot-width, @big-dot-height, @dot-border-width);
           .state-circle-with-border-and-content(@dot-border-width, @wz-color-default);
-        }
-
-        & div a:hover:before {
-          .state-circle-hover(@big-dot-width, @big-dot-height, @dot-border-width);
-          .state-circle-with-border-and-content-hover(@dot-border-width, @wz-color-default);
 
           content: attr(step-symbol);
+        }
+
+        div a:hover:before {
+          .state-circle-hover(@big-dot-width, @big-dot-height, @dot-border-width);
+          .state-circle-with-border-and-content-hover(@dot-border-width, @wz-color-default);
         }
       }
 

--- a/src/components/wizard-navigation-bar.component.horizontal.less
+++ b/src/components/wizard-navigation-bar.component.horizontal.less
@@ -54,9 +54,20 @@ aw-wizard-navigation-bar.horizontal {
     border-radius: 100%;
   }
 
+  .state-circle-hover(@dot-width, @dot-height, @dot-border-width) {
+  }
+
   .state-circle-with-border(@dot-border-width, @circle-color) {
     border-width: @dot-border-width;
     border-style: solid;
+    border-color: @circle-color;
+  }
+
+  .state-circle-with-border-hover(@dot-border-width, @circle-color) {
+    border-color: darken(@circle-color, 10%);
+  }
+
+  .state-circle-with-border-nohover(@dot-border-width, @circle-color) {
     border-color: @circle-color;
   }
 
@@ -65,13 +76,39 @@ aw-wizard-navigation-bar.horizontal {
     color: @circle-color;
   }
 
+  .state-circle-with-border-and-content-hover(@dot-border-width, @circle-color) {
+    .state-circle-with-border-hover(@dot-border-width, @circle-color);
+    color: darken(@circle-color, 20%);
+  }
+
+  .state-circle-with-border-and-content-nohover(@dot-border-width, @circle-color) {
+    .state-circle-with-border-nohover(@dot-border-width, @circle-color);
+    color: @circle-color;
+  }
+
   .state-circle-with-background(@circle-color) {
+    background-color: @circle-color;
+  }
+
+  .state-circle-with-background-hover(@circle-color) {
+    background-color: darken(@circle-color, 5%);
+  }
+
+  .state-circle-with-background-nohover(@circle-color) {
     background-color: @circle-color;
   }
 
   .state-circle-with-background-and-content(@circle-color) {
     .state-circle-with-background(@circle-color);
     color: black;
+  }
+
+  .state-circle-with-background-and-content-hover(@circle-color) {
+    .state-circle-with-background-hover(@circle-color);
+  }
+
+  .state-circle-with-background-and-content-nohover(@circle-color) {
+    .state-circle-with-background-nohover(@circle-color);
   }
 
   &.small {
@@ -83,32 +120,29 @@ aw-wizard-navigation-bar.horizontal {
           .line(@small-dot-width, @small-dot-height, @wz-color-default);
         }
 
-        &:after {
+        & div a:before {
           .state-circle(@small-dot-width, @small-dot-height, 0);
           .state-circle-with-background(@wz-color-default);
         }
+
+        & div a:hover:before {
+          .state-circle-hover(@small-dot-width, @small-dot-height, 0);
+          .state-circle-with-background-hover(@wz-color-default);
+        }
       }
+
+      li.current div a:before { .state-circle-with-background(@wz-color-current); }
+      li.done div a:before { .state-circle-with-background(@wz-color-done); }
+      li.optional div a:before { .state-circle-with-background(@wz-color-optional); }
+      li.editing div a:before { .state-circle-with-background(@wz-color-editing); }
+
+      li.current div a:hover:before { .state-circle-with-background-hover(@wz-color-current); }
+      li.done div a:hover:before { .state-circle-with-background-hover(@wz-color-done); }
+      li.optional div a:hover:before { .state-circle-with-background-hover(@wz-color-optional); }
+      li.editing div a:hover:before { .state-circle-with-background-hover(@wz-color-editing); }
 
       // default steps shouldn't change when hovered, because they aren't clickable
-      li.default a:hover {
-        color: @wz-color-current;
-      }
-
-      li.current:after {
-        .state-circle-with-background(@wz-color-current);
-      }
-
-      li.done:after {
-        .state-circle-with-background(@wz-color-done);
-      }
-
-      li.optional:after {
-        .state-circle-with-background(@wz-color-optional);
-      }
-
-      li.editing:after {
-        .state-circle-with-background(@wz-color-editing);
-      }
+      li.default div a:hover:before { .state-circle-with-background-nohover(@wz-color-current); }
     }
   }
 
@@ -121,32 +155,29 @@ aw-wizard-navigation-bar.horizontal {
           .line(@big-dot-width, @big-dot-height, @wz-color-default);
         }
 
-        &:after {
+        & div a:before {
           .state-circle(@big-dot-width, @big-dot-height, 0);
           .state-circle-with-background(@wz-color-default);
         }
+
+        & div a:hover:before {
+          .state-circle-hover(@big-dot-width, @big-dot-height, 0);
+          .state-circle-with-background-hover(@wz-color-default);
+        }
       }
+
+      li.current div a:before { .state-circle-with-background(@wz-color-current); }
+      li.done div a:before { .state-circle-with-background(@wz-color-done); }
+      li.optional div a:before { .state-circle-with-background(@wz-color-optional); }
+      li.editing div a:before { .state-circle-with-background(@wz-color-editing); }
+
+      li.current div a:hover:before { .state-circle-with-background-hover(@wz-color-current); }
+      li.done div a:hover:before { .state-circle-with-background-hover(@wz-color-done); }
+      li.optional div a:hover:before { .state-circle-with-background-hover(@wz-color-optional); }
+      li.editing div a:hover:before { .state-circle-with-background-hover(@wz-color-editing); }
 
       // default steps shouldn't change when hovered, because they aren't clickable
-      li.default a:hover {
-        color: @wz-color-current;
-      }
-
-      li.current:after {
-        .state-circle-with-background(@wz-color-current);
-      }
-
-      li.done:after {
-        .state-circle-with-background(@wz-color-done);
-      }
-
-      li.optional:after {
-        .state-circle-with-background(@wz-color-optional);
-      }
-
-      li.editing:after {
-        .state-circle-with-background(@wz-color-editing);
-      }
+      li.default div a:hover:before { .state-circle-with-background-nohover(@wz-color-current); }
     }
   }
 
@@ -159,32 +190,29 @@ aw-wizard-navigation-bar.horizontal {
           .line(@big-dot-width, @big-dot-height, @wz-color-default);
         }
 
-        &:after {
+        & div a:before {
           .state-circle(@big-dot-width, @big-dot-height, @dot-border-width);
           .state-circle-with-border(@dot-border-width, @wz-color-default);
         }
+
+        & div a:hover:before {
+          .state-circle-hover(@big-dot-width, @big-dot-height, @dot-border-width);
+          .state-circle-with-border-hover(@dot-border-width, @wz-color-default);
+        }
       }
+
+      li.current div a:before { .state-circle-with-border(@dot-border-width, @wz-color-current); }
+      li.done div a:before { .state-circle-with-border(@dot-border-width, @wz-color-done); }
+      li.optional div a:before { .state-circle-with-border(@dot-border-width, @wz-color-optional); }
+      li.editing div a:before { .state-circle-with-border(@dot-border-width, @wz-color-editing); }
+
+      li.current div a:hover:before { .state-circle-with-border-hover(@dot-border-width, @wz-color-current); }
+      li.done div a:hover:before { .state-circle-with-border-hover(@dot-border-width, @wz-color-done); }
+      li.optional div a:hover:before { .state-circle-with-border-hover(@dot-border-width, @wz-color-optional); }
+      li.editing div a:hover:before { .state-circle-with-border-hover(@dot-border-width, @wz-color-editing); }
 
       // default steps shouldn't change when hovered, because they aren't clickable
-      li.default a:hover {
-        color: @wz-color-current;
-      }
-
-      li.current:after {
-        .state-circle-with-border(@dot-border-width, @wz-color-current);
-      }
-
-      li.done:after {
-        .state-circle-with-border(@dot-border-width, @wz-color-done);
-      }
-
-      li.optional:after {
-        .state-circle-with-border(@dot-border-width, @wz-color-optional);
-      }
-
-      li.editing:after {
-        .state-circle-with-border(@dot-border-width, @wz-color-editing);
-      }
+      li.default div a:hover:before { .state-circle-with-border-nohover(@dot-border-width, @wz-color-current); }
     }
   }
 
@@ -197,34 +225,31 @@ aw-wizard-navigation-bar.horizontal {
           .line(@big-dot-width, @big-dot-height, @wz-color-default);
         }
 
-        &:after {
+        & div a:before {
           .state-circle(@big-dot-width, @big-dot-height, 0);
           .state-circle-with-background-and-content(@wz-color-default);
+        }
+
+        & div a:hover:before {
+          .state-circle-hover(@big-dot-width, @big-dot-height, 0);
+          .state-circle-with-background-and-content-hover(@wz-color-default);
 
           content: attr(step-symbol);
         }
       }
 
+      li.current div a:before { .state-circle-with-background-and-content(@wz-color-current); }
+      li.done div a:before { .state-circle-with-background-and-content(@wz-color-done); }
+      li.optional div a:before { .state-circle-with-background-and-content(@wz-color-optional); }
+      li.editing div a:before { .state-circle-with-background-and-content(@wz-color-editing); }
+
+      li.current div a:hover:before { .state-circle-with-background-and-content-hover(@wz-color-current); }
+      li.done div a:hover:before { .state-circle-with-background-and-content-hover(@wz-color-done); }
+      li.optional div a:hover:before { .state-circle-with-background-and-content-hover(@wz-color-optional); }
+      li.editing div a:hover:before { .state-circle-with-background-and-content-hover(@wz-color-editing); }
+
       // default steps shouldn't change when hovered, because they aren't clickable
-      li.default a:hover {
-        color: @wz-color-current;
-      }
-
-      li.current:after {
-        .state-circle-with-background-and-content(@wz-color-current);
-      }
-
-      li.done:after {
-        .state-circle-with-background-and-content(@wz-color-done);
-      }
-
-      li.optional:after {
-        .state-circle-with-background-and-content(@wz-color-optional);
-      }
-
-      li.editing:after {
-        .state-circle-with-background-and-content(@wz-color-editing);
-      }
+      li.default div a:hover:before { .state-circle-with-background-and-content-nohover(@wz-color-current); }
     }
   }
 
@@ -237,34 +262,31 @@ aw-wizard-navigation-bar.horizontal {
           .line(@big-dot-width, @big-dot-height, @wz-color-default);
         }
 
-        &:after {
+        & div a:before {
           .state-circle(@big-dot-width, @big-dot-height, @dot-border-width);
           .state-circle-with-border-and-content(@dot-border-width, @wz-color-default);
+        }
+
+        & div a:hover:before {
+          .state-circle-hover(@big-dot-width, @big-dot-height, @dot-border-width);
+          .state-circle-with-border-and-content-hover(@dot-border-width, @wz-color-default);
 
           content: attr(step-symbol);
         }
       }
 
+      li.current div a:before { .state-circle-with-border-and-content(@dot-border-width, @wz-color-current); }
+      li.done div a:before { .state-circle-with-border-and-content(@dot-border-width, @wz-color-done); }
+      li.optional div a:before { .state-circle-with-border-and-content(@dot-border-width, @wz-color-optional); }
+      li.editing div a:before { .state-circle-with-border-and-content(@dot-border-width, @wz-color-editing); }
+
+      li.current div a:hover:before { .state-circle-with-border-and-content-hover(@dot-border-width, @wz-color-current); }
+      li.done div a:hover:before { .state-circle-with-border-and-content-hover(@dot-border-width, @wz-color-done); }
+      li.optional div a:hover:before { .state-circle-with-border-and-content-hover(@dot-border-width, @wz-color-optional); }
+      li.editing div a:hover:before { .state-circle-with-border-and-content-hover(@dot-border-width, @wz-color-editing); }
+
       // default steps shouldn't change when hovered, because they aren't clickable
-      li.default a:hover {
-        color: @wz-color-current;
-      }
-
-      li.current:after {
-        .state-circle-with-border-and-content(@dot-border-width, @wz-color-current);
-      }
-
-      li.done:after {
-        .state-circle-with-border-and-content(@dot-border-width, @wz-color-done);
-      }
-
-      li.optional:after {
-        .state-circle-with-border-and-content(@dot-border-width, @wz-color-optional);
-      }
-
-      li.editing:after {
-        .state-circle-with-border-and-content(@dot-border-width, @wz-color-editing);
-      }
+      li.default div a:hover:before { .state-circle-with-border-and-content-nohover(@dot-border-width, @wz-color-current); }
     }
   }
 
@@ -273,9 +295,6 @@ aw-wizard-navigation-bar.horizontal {
     flex-direction: row;
     justify-content: center;
 
-    right: 0;
-    bottom: 0;
-    left: 0;
     margin: 0;
     width: 100%;
     list-style: none;
@@ -361,6 +380,11 @@ aw-wizard-navigation-bar.horizontal {
           }
         }
       }
+    }
+
+    // default steps shouldn't change when hovered, because they aren't clickable
+    li.default div a:hover {
+      color: @wz-color-current;
     }
 
     li.navigable {

--- a/src/components/wizard-navigation-bar.component.html
+++ b/src/components/wizard-navigation-bar.component.html
@@ -1,6 +1,5 @@
 <ul class="steps-indicator steps-{{numberOfWizardSteps}}">
   <li *ngFor="let step of wizardSteps"
-      [attr.step-symbol]="step.navigationSymbol.symbol"
       [ngStyle]="{
         'font-family': step.navigationSymbol.fontFamily
       }"
@@ -13,7 +12,7 @@
         navigable: isNavigable(step)
   }">
     <div>
-      <a [awGoToStep]="step">
+      <a [awGoToStep]="step" [attr.step-symbol]="step.navigationSymbol.symbol">
         <ng-container *ngIf="step.stepTitleTemplate" [ngTemplateOutlet]="step.stepTitleTemplate.templateRef"></ng-container>
         <ng-container *ngIf="!step.stepTitleTemplate">{{step.stepTitle}}</ng-container>
       </a>

--- a/src/components/wizard-navigation-bar.component.html
+++ b/src/components/wizard-navigation-bar.component.html
@@ -1,8 +1,5 @@
 <ul class="steps-indicator steps-{{numberOfWizardSteps}}">
   <li *ngFor="let step of wizardSteps"
-      [ngStyle]="{
-        'font-family': step.navigationSymbol.fontFamily
-      }"
       [ngClass]="{
         default: isDefault(step),
         current: isCurrent(step),
@@ -12,7 +9,9 @@
         navigable: isNavigable(step)
   }">
     <div>
-      <a [awGoToStep]="step" [attr.step-symbol]="step.navigationSymbol.symbol">
+      <a [awGoToStep]="step"
+         [attr.step-symbol]="step.navigationSymbol.symbol"
+         [ngStyle]="{ 'font-family': step.navigationSymbol.fontFamily }">
         <ng-container *ngIf="step.stepTitleTemplate" [ngTemplateOutlet]="step.stepTitleTemplate.templateRef"></ng-container>
         <ng-container *ngIf="!step.stepTitleTemplate">{{step.stepTitle}}</ng-container>
       </a>

--- a/src/components/wizard-navigation-bar.component.vertical.less
+++ b/src/components/wizard-navigation-bar.component.vertical.less
@@ -62,9 +62,20 @@ aw-wizard-navigation-bar.vertical {
     border-radius: 100%;
   }
 
+  .state-circle-hover(@dot-width, @dot-height, @dot-border-width) {
+  }
+
   .state-circle-with-border(@dot-border-width, @circle-color) {
     border-width: @dot-border-width;
     border-style: solid;
+    border-color: @circle-color;
+  }
+
+  .state-circle-with-border-hover(@dot-border-width, @circle-color) {
+    border-color: darken(@circle-color, 10%);
+  }
+
+  .state-circle-with-border-nohover(@dot-border-width, @circle-color) {
     border-color: @circle-color;
   }
 
@@ -73,13 +84,39 @@ aw-wizard-navigation-bar.vertical {
     color: @circle-color;
   }
 
+  .state-circle-with-border-and-content-hover(@dot-border-width, @circle-color) {
+    .state-circle-with-border-hover(@dot-border-width, @circle-color);
+    color: darken(@circle-color, 20%);
+  }
+
+  .state-circle-with-border-and-content-nohover(@dot-border-width, @circle-color) {
+    .state-circle-with-border-nohover(@dot-border-width, @circle-color);
+    color: @circle-color;
+  }
+
   .state-circle-with-background(@circle-color) {
+    background-color: @circle-color;
+  }
+
+  .state-circle-with-background-hover(@circle-color) {
+    background-color: darken(@circle-color, 5%);
+  }
+
+  .state-circle-with-background-nohover(@circle-color) {
     background-color: @circle-color;
   }
 
   .state-circle-with-background-and-content(@circle-color) {
     .state-circle-with-background(@circle-color);
     color: black;
+  }
+
+  .state-circle-with-background-and-content-hover(@circle-color) {
+    .state-circle-with-background-hover(@circle-color);
+  }
+
+  .state-circle-with-background-and-content-nohover(@circle-color) {
+    .state-circle-with-background-nohover(@circle-color);
   }
 
   &.small {
@@ -91,7 +128,7 @@ aw-wizard-navigation-bar.vertical {
           .line(@small-dot-width, @small-dot-height, @wz-color-default);
         }
 
-        &:after {
+        & div a:before {
           .state-circle(@small-dot-width, @small-dot-height, 0);
           .state-circle-with-background(@wz-color-default);
         }
@@ -101,26 +138,18 @@ aw-wizard-navigation-bar.vertical {
         }
       }
 
+      li.current div a:before { .state-circle-with-background(@wz-color-current); }
+      li.done div a:before { .state-circle-with-background(@wz-color-done); }
+      li.optional div a:before { .state-circle-with-background(@wz-color-optional); }
+      li.editing div a:before { .state-circle-with-background(@wz-color-editing); }
+
+      li.current div a:hover:before { .state-circle-with-background-hover(@wz-color-current); }
+      li.done div a:hover:before { .state-circle-with-background-hover(@wz-color-done); }
+      li.optional div a:hover:before { .state-circle-with-background-hover(@wz-color-optional); }
+      li.editing div a:hover:before { .state-circle-with-background-hover(@wz-color-editing); }
+
       // default steps shouldn't change when hovered, because they aren't clickable
-      li.default a:hover {
-        color: @wz-color-current;
-      }
-
-      li.current:after {
-        .state-circle-with-background(@wz-color-current);
-      }
-
-      li.done:after {
-        .state-circle-with-background(@wz-color-done);
-      }
-
-      li.optional:after {
-        .state-circle-with-background(@wz-color-optional);
-      }
-
-      li.editing:after {
-        .state-circle-with-background(@wz-color-editing);
-      }
+      li.default div a:before { .state-circle-with-background-nohover(@wz-color-current); }
     }
   }
 
@@ -133,7 +162,7 @@ aw-wizard-navigation-bar.vertical {
           .line(@big-dot-width, @big-dot-height, @wz-color-default);
         }
 
-        &:after {
+        & div a:before {
           .state-circle(@big-dot-width, @big-dot-height, 0);
           .state-circle-with-background(@wz-color-default);
         }
@@ -143,26 +172,18 @@ aw-wizard-navigation-bar.vertical {
         }
       }
 
+      li.current div a:before { .state-circle-with-background(@wz-color-current); }
+      li.done div a:before { .state-circle-with-background(@wz-color-done); }
+      li.optional div a:before { .state-circle-with-background(@wz-color-optional); }
+      li.editing div a:before { .state-circle-with-background(@wz-color-editing); }
+
+      li.current div a:hover:before { .state-circle-with-background-hover(@wz-color-current); }
+      li.done div a:hover:before { .state-circle-with-background-hover(@wz-color-done); }
+      li.optional div a:hover:before { .state-circle-with-background-hover(@wz-color-optional); }
+      li.editing div a:hover:before { .state-circle-with-background-hover(@wz-color-editing); }
+
       // default steps shouldn't change when hovered, because they aren't clickable
-      li.default a:hover {
-        color: @wz-color-current;
-      }
-
-      li.current:after {
-        .state-circle-with-background(@wz-color-current);
-      }
-
-      li.done:after {
-        .state-circle-with-background(@wz-color-done);
-      }
-
-      li.optional:after {
-        .state-circle-with-background(@wz-color-optional);
-      }
-
-      li.editing:after {
-        .state-circle-with-background(@wz-color-editing);
-      }
+      li.default div a:before { .state-circle-with-background-nohover(@wz-color-current); }
     }
   }
 
@@ -175,7 +196,7 @@ aw-wizard-navigation-bar.vertical {
           .line(@big-dot-width, @big-dot-height, @wz-color-default);
         }
 
-        &:after {
+        & div a:before {
           .state-circle(@big-dot-width, @big-dot-height, @dot-border-width);
           .state-circle-with-border(@dot-border-width, @wz-color-default);
         }
@@ -185,26 +206,18 @@ aw-wizard-navigation-bar.vertical {
         }
       }
 
+      li.current div a:before { .state-circle-with-border(@dot-border-width, @wz-color-current); }
+      li.done div a:before { .state-circle-with-border(@dot-border-width, @wz-color-done); }
+      li.optional div a:before { .state-circle-with-border(@dot-border-width, @wz-color-optional); }
+      li.editing div a:before { .state-circle-with-border(@dot-border-width, @wz-color-editing); }
+
+      li.current div a:hover:before { .state-circle-with-border-hover(@dot-border-width, @wz-color-current); }
+      li.done div a:hover:before { .state-circle-with-border-hover(@dot-border-width, @wz-color-done); }
+      li.optional div a:hover:before { .state-circle-with-border-hover(@dot-border-width, @wz-color-optional); }
+      li.editing div a:hover:before { .state-circle-with-border-hover(@dot-border-width, @wz-color-editing); }
+
       // default steps shouldn't change when hovered, because they aren't clickable
-      li.default a:hover {
-        color: @wz-color-current;
-      }
-
-      li.current:after {
-        .state-circle-with-border(@dot-border-width, @wz-color-current);
-      }
-
-      li.done:after {
-        .state-circle-with-border(@dot-border-width, @wz-color-done);
-      }
-
-      li.optional:after {
-        .state-circle-with-border(@dot-border-width, @wz-color-optional);
-      }
-
-      li.editing:after {
-        .state-circle-with-border(@dot-border-width, @wz-color-editing);
-      }
+      li.default div a:before { .state-circle-with-border-nohover(@dot-border-width, @wz-color-current); }
     }
   }
 
@@ -217,7 +230,7 @@ aw-wizard-navigation-bar.vertical {
           .line(@big-dot-width, @big-dot-height, @wz-color-default);
         }
 
-        &:after {
+        & div a:before {
           .state-circle(@big-dot-width, @big-dot-height, 0);
           .state-circle-with-background-and-content(@wz-color-default);
 
@@ -229,26 +242,18 @@ aw-wizard-navigation-bar.vertical {
         }
       }
 
+      li.current div a:before { .state-circle-with-background-and-content(@wz-color-current); }
+      li.done div a:before { .state-circle-with-background-and-content(@wz-color-done); }
+      li.optional div a:before { .state-circle-with-background-and-content(@wz-color-optional); }
+      li.editing div a:before { .state-circle-with-background-and-content(@wz-color-editing); }
+
+      li.current div a:hover:before { .state-circle-with-background-and-content-hover(@wz-color-current); }
+      li.done div a:hover:before { .state-circle-with-background-and-content-hover(@wz-color-done); }
+      li.optional div a:hover:before { .state-circle-with-background-and-content-hover(@wz-color-optional); }
+      li.editing div a:hover:before { .state-circle-with-background-and-content-hover(@wz-color-editing); }
+
       // default steps shouldn't change when hovered, because they aren't clickable
-      li.default a:hover {
-        color: @wz-color-current;
-      }
-
-      li.current:after {
-        .state-circle-with-background-and-content(@wz-color-current);
-      }
-
-      li.done:after {
-        .state-circle-with-background-and-content(@wz-color-done);
-      }
-
-      li.optional:after {
-        .state-circle-with-background-and-content(@wz-color-optional);
-      }
-
-      li.editing:after {
-        .state-circle-with-background-and-content(@wz-color-editing);
-      }
+      li.default div a:before { .state-circle-with-background-and-content-nohover(@wz-color-current); }
     }
   }
 
@@ -261,7 +266,7 @@ aw-wizard-navigation-bar.vertical {
           .line(@big-dot-width, @big-dot-height, @wz-color-default);
         }
 
-        &:after {
+        & div a:before {
           .state-circle(@big-dot-width, @big-dot-height, @dot-border-width);
           .state-circle-with-border-and-content(@dot-border-width, @wz-color-default);
 
@@ -273,26 +278,18 @@ aw-wizard-navigation-bar.vertical {
         }
       }
 
+      li.current div a:before { .state-circle-with-border-and-content(@dot-border-width, @wz-color-current); }
+      li.done div a:before { .state-circle-with-border-and-content(@dot-border-width, @wz-color-done); }
+      li.optional div a:before { .state-circle-with-border-and-content(@dot-border-width, @wz-color-optional); }
+      li.editing div a:before { .state-circle-with-border-and-content(@dot-border-width, @wz-color-editing); }
+
+      li.current div a:hover:before { .state-circle-with-border-and-content-hover(@dot-border-width, @wz-color-current); }
+      li.done div a:hover:before { .state-circle-with-border-and-content-hover(@dot-border-width, @wz-color-done); }
+      li.optional div a:hover:before { .state-circle-with-border-and-content-hover(@dot-border-width, @wz-color-optional); }
+      li.editing div a:hover:before { .state-circle-with-border-and-content-hover(@dot-border-width, @wz-color-editing); }
+
       // default steps shouldn't change when hovered, because they aren't clickable
-      li.default a:hover {
-        color: @wz-color-current;
-      }
-
-      li.current:after {
-        .state-circle-with-border-and-content(@dot-border-width, @wz-color-current);
-      }
-
-      li.done:after {
-        .state-circle-with-border-and-content(@dot-border-width, @wz-color-done);
-      }
-
-      li.optional:after {
-        .state-circle-with-border-and-content(@dot-border-width, @wz-color-optional);
-      }
-
-      li.editing:after {
-        .state-circle-with-border-and-content(@dot-border-width, @wz-color-editing);
-      }
+      li.default div a:before { .state-circle-with-border-and-content-nohover(@dot-border-width, @wz-color-current); }
     }
   }
 
@@ -342,6 +339,11 @@ aw-wizard-navigation-bar.vertical {
           }
         }
       }
+    }
+
+    // default steps shouldn't change when hovered, because they aren't clickable
+    li.default div a:hover {
+      color: @wz-color-current;
     }
 
     li.navigable {

--- a/src/components/wizard-navigation-bar.component.vertical.less
+++ b/src/components/wizard-navigation-bar.component.vertical.less
@@ -128,9 +128,14 @@ aw-wizard-navigation-bar.vertical {
           .line(@small-dot-width, @small-dot-height, @wz-color-default);
         }
 
-        & div a:before {
+        div a:before {
           .state-circle(@small-dot-width, @small-dot-height, 0);
           .state-circle-with-background(@wz-color-default);
+        }
+
+        div a:hover:before {
+          .state-circle-hover(@small-dot-width, @small-dot-height, 0);
+          .state-circle-with-background-hover(@wz-color-default);
         }
 
         div {
@@ -162,9 +167,14 @@ aw-wizard-navigation-bar.vertical {
           .line(@big-dot-width, @big-dot-height, @wz-color-default);
         }
 
-        & div a:before {
+        div a:before {
           .state-circle(@big-dot-width, @big-dot-height, 0);
           .state-circle-with-background(@wz-color-default);
+        }
+
+        div a:hover:before {
+          .state-circle-hover(@big-dot-width, @big-dot-height, 0);
+          .state-circle-with-background-hover(@wz-color-default);
         }
 
         div {
@@ -196,9 +206,14 @@ aw-wizard-navigation-bar.vertical {
           .line(@big-dot-width, @big-dot-height, @wz-color-default);
         }
 
-        & div a:before {
+        div a:before {
           .state-circle(@big-dot-width, @big-dot-height, @dot-border-width);
           .state-circle-with-border(@dot-border-width, @wz-color-default);
+        }
+
+        div a:hover:before {
+          .state-circle-hover(@big-dot-width, @big-dot-height, @dot-border-width);
+          .state-circle-with-border-hover(@dot-border-width, @wz-color-default);
         }
 
         div {
@@ -230,11 +245,16 @@ aw-wizard-navigation-bar.vertical {
           .line(@big-dot-width, @big-dot-height, @wz-color-default);
         }
 
-        & div a:before {
+        div a:before {
           .state-circle(@big-dot-width, @big-dot-height, 0);
           .state-circle-with-background-and-content(@wz-color-default);
 
           content: attr(step-symbol);
+        }
+
+        div a:hover:before {
+          .state-circle-hover(@big-dot-width, @big-dot-height, 0);
+          .state-circle-with-background-and-content-hover(@wz-color-default);
         }
 
         div {
@@ -266,11 +286,16 @@ aw-wizard-navigation-bar.vertical {
           .line(@big-dot-width, @big-dot-height, @wz-color-default);
         }
 
-        & div a:before {
+        div a:before {
           .state-circle(@big-dot-width, @big-dot-height, @dot-border-width);
           .state-circle-with-border-and-content(@dot-border-width, @wz-color-default);
 
           content: attr(step-symbol);
+        }
+
+        div a:hover:before {
+          .state-circle-hover(@big-dot-width, @big-dot-height, @dot-border-width);
+          .state-circle-with-border-and-content-hover(@dot-border-width, @wz-color-default);
         }
 
         div {


### PR DESCRIPTION
Fixes #118.

# Description of the changes

The changes basically boil down to moving step indicators from `li:after` to `li div a:before`. The diff looks so huge because there is a lot of boilerplate in the styles.

Just like the text, step indicators are now highlighted on hover when they are clickable. While text is darkened by 20%, a border of an empty circle is darkened by 10, and background of a filled color is darkened by 5. This is because a change in, for example, background color is more visible than in text color.

# Testing

I have tested my changes using [angular-archwizard-demo][1] (very well-made, thank you!) using all layouts, both in a horizontal and a vertical location.

Tested browsers:
- Google Chrome 67.0.3396.99
- Microsoft Edge Microsoft Edge 38.14393.2068.0

I have also run `npm test` which, of course, did not report any problems.

# Implementation notes

Thanks to absolute positioning you use for step indicators, the clickable area in horizontal layouts is as follows (marked with blue):

![clickable area](https://user-images.githubusercontent.com/52021/42135974-09686164-7d5c-11e8-8c78-4385c77a0121.png)

I think, this is the desired behavior.

# Compatibility notes

The changes might break wizard styling for developers who customized step indicators styles using `li:after` selector. They should now use `li div a:before` instead.

[1]: <https://github.com/madoar/angular-archwizard-demo/>