### PR TITLE
Step symbol template

### DIFF
--- a/src/archwizard.module.ts
+++ b/src/archwizard.module.ts
@@ -10,6 +10,7 @@ import {NextStepDirective} from './directives/next-step.directive';
 import {PreviousStepDirective} from './directives/previous-step.directive';
 import {OptionalStepDirective} from './directives/optional-step.directive';
 import {GoToStepDirective} from './directives/go-to-step.directive';
+import {WizardStepSymbolDirective} from './directives/wizard-step-symbol.directive';
 import {WizardStepTitleDirective} from './directives/wizard-step-title.directive';
 import {EnableBackLinksDirective} from './directives/enable-back-links.directive';
 import {WizardStepDirective} from './directives/wizard-step.directive';
@@ -32,6 +33,7 @@ import {ResetWizardDirective} from './directives/reset-wizard.directive';
     NextStepDirective,
     PreviousStepDirective,
     OptionalStepDirective,
+    WizardStepSymbolDirective,
     WizardStepTitleDirective,
     EnableBackLinksDirective,
     WizardStepDirective,
@@ -51,6 +53,7 @@ import {ResetWizardDirective} from './directives/reset-wizard.directive';
     NextStepDirective,
     PreviousStepDirective,
     OptionalStepDirective,
+    WizardStepSymbolDirective,
     WizardStepTitleDirective,
     EnableBackLinksDirective,
     WizardStepDirective,

--- a/src/components/wizard-navigation-bar.component.horizontal.less
+++ b/src/components/wizard-navigation-bar.component.horizontal.less
@@ -46,12 +46,15 @@ aw-wizard-navigation-bar.horizontal {
     left: calc(50% ~'-' @dot-width / 2);
     width: @dot-width;
     height: @dot-height;
-    content: '';
     text-align: center;
     vertical-align: middle;
     line-height: @dot-height - 2 * @dot-border-width;
     transition: 0.25s;
     border-radius: 100%;
+  }
+  .state-circle-hover(@dot-width, @dot-height, @dot-border-width) {
+  }
+  .state-circle-nohover(@dot-width, @dot-height, @dot-border-width) {
   }
 
   .state-circle-with-border(@dot-border-width, @circle-color) {
@@ -59,19 +62,45 @@ aw-wizard-navigation-bar.horizontal {
     border-style: solid;
     border-color: @circle-color;
   }
+  .state-circle-with-border-hover(@dot-border-width, @circle-color) {
+    border-color: darken(@circle-color, 10%);
+  }
+  .state-circle-with-border-nohover(@dot-border-width, @circle-color) {
+    border-color: @circle-color;
+  }
 
   .state-circle-with-border-and-content(@dot-border-width, @circle-color) {
     .state-circle-with-border(@dot-border-width, @circle-color);
+    color: @circle-color;
+  }
+  .state-circle-with-border-and-content-hover(@dot-border-width, @circle-color) {
+    .state-circle-with-border-hover(@dot-border-width, @circle-color);
+    color: darken(@circle-color, 10%);
+  }
+  .state-circle-with-border-and-content-nohover(@dot-border-width, @circle-color) {
+    .state-circle-with-border-nohover(@dot-border-width, @circle-color);
     color: @circle-color;
   }
 
   .state-circle-with-background(@circle-color) {
     background-color: @circle-color;
   }
+  .state-circle-with-background-hover(@circle-color) {
+    background-color: darken(@circle-color, 5%);
+  }
+  .state-circle-with-background-nohover(@circle-color) {
+    background-color: @circle-color;
+  }
 
   .state-circle-with-background-and-content(@circle-color) {
     .state-circle-with-background(@circle-color);
     color: black;
+  }
+  .state-circle-with-background-and-content-hover(@circle-color) {
+    .state-circle-with-background-hover(@circle-color);
+  }
+  .state-circle-with-background-and-content-nohover(@circle-color) {
+    .state-circle-with-background-nohover(@circle-color);
   }
 
   &.small {
@@ -83,32 +112,29 @@ aw-wizard-navigation-bar.horizontal {
           .line(@small-dot-width, @small-dot-height, @wz-color-default);
         }
 
-        &:after {
+        .step-indicator {
           .state-circle(@small-dot-width, @small-dot-height, 0);
           .state-circle-with-background(@wz-color-default);
         }
+
+        a:hover .step-indicator {
+          .state-circle-hover(@small-dot-width, @small-dot-height, 0);
+          .state-circle-with-background-hover(@wz-color-default);
+        }
       }
+
+      li.current .step-indicator { .state-circle-with-background(@wz-color-current); }
+      li.done .step-indicator { .state-circle-with-background(@wz-color-done); }
+      li.optional .step-indicator { .state-circle-with-background(@wz-color-optional); }
+      li.editing .step-indicator { .state-circle-with-background(@wz-color-editing); }
+
+      li.current a:hover .step-indicator { .state-circle-with-background-hover(@wz-color-current); }
+      li.done a:hover .step-indicator { .state-circle-with-background-hover(@wz-color-done); }
+      li.optional a:hover .step-indicator { .state-circle-with-background-hover(@wz-color-optional); }
+      li.editing a:hover .step-indicator { .state-circle-with-background-hover(@wz-color-editing); }
 
       // default steps shouldn't change when hovered, because they aren't clickable
-      li.default a:hover {
-        color: @wz-color-current;
-      }
-
-      li.current:after {
-        .state-circle-with-background(@wz-color-current);
-      }
-
-      li.done:after {
-        .state-circle-with-background(@wz-color-done);
-      }
-
-      li.optional:after {
-        .state-circle-with-background(@wz-color-optional);
-      }
-
-      li.editing:after {
-        .state-circle-with-background(@wz-color-editing);
-      }
+      li.default a:hover .step-indicator { .state-circle-with-background-nohover(@wz-color-current); }
     }
   }
 
@@ -121,32 +147,29 @@ aw-wizard-navigation-bar.horizontal {
           .line(@big-dot-width, @big-dot-height, @wz-color-default);
         }
 
-        &:after {
+        .step-indicator {
           .state-circle(@big-dot-width, @big-dot-height, 0);
           .state-circle-with-background(@wz-color-default);
         }
+
+        a:hover .step-indicator {
+          .state-circle-hover(@big-dot-width, @big-dot-height, 0);
+          .state-circle-with-background-hover(@wz-color-default);
+        }
       }
+
+      li.current .step-indicator { .state-circle-with-background(@wz-color-current); }
+      li.done .step-indicator { .state-circle-with-background(@wz-color-done); }
+      li.optional .step-indicator { .state-circle-with-background(@wz-color-optional); }
+      li.editing .step-indicator { .state-circle-with-background(@wz-color-editing); }
+
+      li.current a:hover .step-indicator { .state-circle-with-background-hover(@wz-color-current); }
+      li.done a:hover .step-indicator { .state-circle-with-background-hover(@wz-color-done); }
+      li.optional a:hover .step-indicator { .state-circle-with-background-hover(@wz-color-optional); }
+      li.editing a:hover .step-indicator { .state-circle-with-background-hover(@wz-color-editing); }
 
       // default steps shouldn't change when hovered, because they aren't clickable
-      li.default a:hover {
-        color: @wz-color-current;
-      }
-
-      li.current:after {
-        .state-circle-with-background(@wz-color-current);
-      }
-
-      li.done:after {
-        .state-circle-with-background(@wz-color-done);
-      }
-
-      li.optional:after {
-        .state-circle-with-background(@wz-color-optional);
-      }
-
-      li.editing:after {
-        .state-circle-with-background(@wz-color-editing);
-      }
+      li.default a:hover .step-indicator { .state-circle-with-background-nohover(@wz-color-current); }
     }
   }
 
@@ -159,32 +182,29 @@ aw-wizard-navigation-bar.horizontal {
           .line(@big-dot-width, @big-dot-height, @wz-color-default);
         }
 
-        &:after {
+        .step-indicator {
           .state-circle(@big-dot-width, @big-dot-height, @dot-border-width);
           .state-circle-with-border(@dot-border-width, @wz-color-default);
         }
+
+        a:hover .step-indicator {
+          .state-circle-hover(@big-dot-width, @big-dot-height, @dot-border-width);
+          .state-circle-with-border-hover(@dot-border-width, @wz-color-default);
+        }
       }
+
+      li.current .step-indicator { .state-circle-with-border(@dot-border-width, @wz-color-current); }
+      li.done .step-indicator { .state-circle-with-border(@dot-border-width, @wz-color-done); }
+      li.optional .step-indicator { .state-circle-with-border(@dot-border-width, @wz-color-optional); }
+      li.editing .step-indicator { .state-circle-with-border(@dot-border-width, @wz-color-editing); }
+
+      li.current a:hover .step-indicator { .state-circle-with-border-hover(@dot-border-width, @wz-color-current); }
+      li.done a:hover .step-indicator { .state-circle-with-border-hover(@dot-border-width, @wz-color-done); }
+      li.optional a:hover .step-indicator { .state-circle-with-border-hover(@dot-border-width, @wz-color-optional); }
+      li.editing a:hover .step-indicator { .state-circle-with-border-hover(@dot-border-width, @wz-color-editing); }
 
       // default steps shouldn't change when hovered, because they aren't clickable
-      li.default a:hover {
-        color: @wz-color-current;
-      }
-
-      li.current:after {
-        .state-circle-with-border(@dot-border-width, @wz-color-current);
-      }
-
-      li.done:after {
-        .state-circle-with-border(@dot-border-width, @wz-color-done);
-      }
-
-      li.optional:after {
-        .state-circle-with-border(@dot-border-width, @wz-color-optional);
-      }
-
-      li.editing:after {
-        .state-circle-with-border(@dot-border-width, @wz-color-editing);
-      }
+      li.default a:hover .step-indicator { .state-circle-with-border-nohover(@dot-border-width, @wz-color-current); }
     }
   }
 
@@ -197,34 +217,33 @@ aw-wizard-navigation-bar.horizontal {
           .line(@big-dot-width, @big-dot-height, @wz-color-default);
         }
 
-        &:after {
+        .step-indicator {
           .state-circle(@big-dot-width, @big-dot-height, 0);
           .state-circle-with-background-and-content(@wz-color-default);
 
-          content: attr(step-symbol);
+          &:before {
+            content: attr(step-symbol);
+          }
+        }
+
+        a:hover .step-indicator {
+          .state-circle-hover(@big-dot-width, @big-dot-height, 0);
+          .state-circle-with-background-and-content-hover(@wz-color-default);
         }
       }
 
+      li.current .step-indicator { .state-circle-with-background-and-content(@wz-color-current); }
+      li.done .step-indicator { .state-circle-with-background-and-content(@wz-color-done); }
+      li.optional .step-indicator { .state-circle-with-background-and-content(@wz-color-optional); }
+      li.editing .step-indicator { .state-circle-with-background-and-content(@wz-color-editing); }
+
+      li.current a:hover .step-indicator { .state-circle-with-background-and-content-hover(@wz-color-current); }
+      li.done a:hover .step-indicator { .state-circle-with-background-and-content-hover(@wz-color-done); }
+      li.optional a:hover .step-indicator { .state-circle-with-background-and-content-hover(@wz-color-optional); }
+      li.editing a:hover .step-indicator { .state-circle-with-background-and-content-hover(@wz-color-editing); }
+
       // default steps shouldn't change when hovered, because they aren't clickable
-      li.default a:hover {
-        color: @wz-color-current;
-      }
-
-      li.current:after {
-        .state-circle-with-background-and-content(@wz-color-current);
-      }
-
-      li.done:after {
-        .state-circle-with-background-and-content(@wz-color-done);
-      }
-
-      li.optional:after {
-        .state-circle-with-background-and-content(@wz-color-optional);
-      }
-
-      li.editing:after {
-        .state-circle-with-background-and-content(@wz-color-editing);
-      }
+      li.default a:hover .step-indicator { .state-circle-with-background-and-content-nohover(@wz-color-current); }
     }
   }
 
@@ -237,34 +256,33 @@ aw-wizard-navigation-bar.horizontal {
           .line(@big-dot-width, @big-dot-height, @wz-color-default);
         }
 
-        &:after {
+        .step-indicator {
           .state-circle(@big-dot-width, @big-dot-height, @dot-border-width);
           .state-circle-with-border-and-content(@dot-border-width, @wz-color-default);
 
-          content: attr(step-symbol);
+          &:before {
+            content: attr(step-symbol);
+          }
+        }
+
+        a:hover .step-indicator {
+          .state-circle-hover(@big-dot-width, @big-dot-height, @dot-border-width);
+          .state-circle-with-border-and-content-hover(@dot-border-width, @wz-color-default);
         }
       }
 
+      li.current .step-indicator { .state-circle-with-border-and-content(@dot-border-width, @wz-color-current); }
+      li.done .step-indicator { .state-circle-with-border-and-content(@dot-border-width, @wz-color-done); }
+      li.optional .step-indicator { .state-circle-with-border-and-content(@dot-border-width, @wz-color-optional); }
+      li.editing .step-indicator { .state-circle-with-border-and-content(@dot-border-width, @wz-color-editing); }
+
+      li.current a:hover .step-indicator { .state-circle-with-border-and-content-hover(@dot-border-width, @wz-color-current); }
+      li.done a:hover .step-indicator { .state-circle-with-border-and-content-hover(@dot-border-width, @wz-color-done); }
+      li.optional a:hover .step-indicator { .state-circle-with-border-and-content-hover(@dot-border-width, @wz-color-optional); }
+      li.editing a:hover .step-indicator { .state-circle-with-border-and-content-hover(@dot-border-width, @wz-color-editing); }
+
       // default steps shouldn't change when hovered, because they aren't clickable
-      li.default a:hover {
-        color: @wz-color-current;
-      }
-
-      li.current:after {
-        .state-circle-with-border-and-content(@dot-border-width, @wz-color-current);
-      }
-
-      li.done:after {
-        .state-circle-with-border-and-content(@dot-border-width, @wz-color-done);
-      }
-
-      li.optional:after {
-        .state-circle-with-border-and-content(@dot-border-width, @wz-color-optional);
-      }
-
-      li.editing:after {
-        .state-circle-with-border-and-content(@dot-border-width, @wz-color-editing);
-      }
+      li.default a:hover .step-indicator { .state-circle-with-border-and-content-nohover(@dot-border-width, @wz-color-current); }
     }
   }
 
@@ -273,9 +291,6 @@ aw-wizard-navigation-bar.horizontal {
     flex-direction: row;
     justify-content: center;
 
-    right: 0;
-    bottom: 0;
-    left: 0;
     margin: 0;
     width: 100%;
     list-style: none;
@@ -337,29 +352,41 @@ aw-wizard-navigation-bar.horizontal {
     li {
       position: relative;
       margin: 0;
-      padding: @text-padding-bottom 0 0 0;
+      padding: 0;
       pointer-events: none;
+      text-align: center;
 
-      div {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
+      a {
+        cursor: pointer;
+      }
 
-        a {
-          color: @wz-color-current;
-          line-height: @text-height;
-          font-size: @text-height;
-          text-decoration: none;
-          text-transform: uppercase;
-          text-align: center;
-          font-weight: bold;
-          transition: 0.25s;
-          cursor: pointer;
+      .label {
+        display: inline-block;
+        padding-top: @text-padding-bottom;
+        color: @wz-color-current;
+        line-height: @text-height;
+        font-size: @text-height;
+        text-decoration: none;
+        text-transform: uppercase;
+        text-align: center;
+        font-weight: bold;
+        transition: 0.25s;
+      }
+    }
 
-          &:hover {
-            color: darken(@wz-color-current, 20%);
-          }
-        }
+    li a:hover .label {
+      color: darken(@wz-color-current, 20%);
+    }
+
+    // default steps shouldn't change when hovered, because they aren't clickable
+    li.default {
+
+      a {
+        cursor: auto;
+      }
+
+      .label {
+        color: @wz-color-current;
       }
     }
 
@@ -368,4 +395,3 @@ aw-wizard-navigation-bar.horizontal {
     }
   }
 }
-

--- a/src/components/wizard-navigation-bar.component.html
+++ b/src/components/wizard-navigation-bar.component.html
@@ -1,9 +1,5 @@
 <ul class="steps-indicator steps-{{numberOfWizardSteps}}">
   <li *ngFor="let step of wizardSteps"
-      [attr.step-symbol]="step.navigationSymbol.symbol"
-      [ngStyle]="{
-        'font-family': step.navigationSymbol.fontFamily
-      }"
       [ngClass]="{
         default: isDefault(step),
         current: isCurrent(step),
@@ -12,11 +8,14 @@
         optional: isOptional(step),
         navigable: isNavigable(step)
   }">
-    <div>
-      <a [awGoToStep]="step">
+    <a [awGoToStep]="step">
+      <div class="label">
         <ng-container *ngIf="step.stepTitleTemplate" [ngTemplateOutlet]="step.stepTitleTemplate.templateRef"></ng-container>
         <ng-container *ngIf="!step.stepTitleTemplate">{{step.stepTitle}}</ng-container>
-      </a>
-    </div>
+      </div>
+      <div class="step-indicator"
+        [attr.step-symbol]="step.navigationSymbol.symbol"
+        [ngStyle]="{ 'font-family': step.navigationSymbol.fontFamily }"></div>
+    </a>
   </li>
 </ul>

--- a/src/components/wizard-navigation-bar.component.html
+++ b/src/components/wizard-navigation-bar.component.html
@@ -13,7 +13,10 @@
         <ng-container *ngIf="step.stepTitleTemplate" [ngTemplateOutlet]="step.stepTitleTemplate.templateRef"></ng-container>
         <ng-container *ngIf="!step.stepTitleTemplate">{{step.stepTitle}}</ng-container>
       </div>
-      <div class="step-indicator"
+      <div *ngIf="step.stepSymbolTemplate" class="step-indicator">
+        <ng-container [ngTemplateOutlet]="step.stepSymbolTemplate.templateRef"></ng-container>
+      </div>
+      <div *ngIf="!step.stepSymbolTemplate" class="step-indicator"
         [attr.step-symbol]="step.navigationSymbol.symbol"
         [ngStyle]="{ 'font-family': step.navigationSymbol.fontFamily }"></div>
     </a>

--- a/src/components/wizard-navigation-bar.component.vertical.less
+++ b/src/components/wizard-navigation-bar.component.vertical.less
@@ -54,7 +54,6 @@ aw-wizard-navigation-bar.vertical {
     left: -(@dot-baseline-distance + @dot-width);
     width: @dot-width;
     height: @dot-height;
-    content: '';
     text-align: center;
     vertical-align: middle;
     line-height: @dot-height - 2 * @dot-border-width;
@@ -62,9 +61,20 @@ aw-wizard-navigation-bar.vertical {
     border-radius: 100%;
   }
 
+  .state-circle-hover(@dot-width, @dot-height, @dot-border-width) {
+  }
+  .state-circle-nohover(@dot-width, @dot-height, @dot-border-width) {
+  }
+
   .state-circle-with-border(@dot-border-width, @circle-color) {
     border-width: @dot-border-width;
     border-style: solid;
+    border-color: @circle-color;
+  }
+  .state-circle-with-border-hover(@dot-border-width, @circle-color) {
+    border-color: darken(@circle-color, 10%);
+  }
+  .state-circle-with-border-nohover(@dot-border-width, @circle-color) {
     border-color: @circle-color;
   }
 
@@ -72,14 +82,34 @@ aw-wizard-navigation-bar.vertical {
     .state-circle-with-border(@dot-border-width, @circle-color);
     color: @circle-color;
   }
+  .state-circle-with-border-and-content-hover(@dot-border-width, @circle-color) {
+    .state-circle-with-border-hover(@dot-border-width, @circle-color);
+    color: darken(@circle-color, 10%);
+  }
+  .state-circle-with-border-and-content-nohover(@dot-border-width, @circle-color) {
+    .state-circle-with-border-nohover(@dot-border-width, @circle-color);
+    color: @circle-color;
+  }
 
   .state-circle-with-background(@circle-color) {
+    background-color: @circle-color;
+  }
+  .state-circle-with-background-hover(@circle-color) {
+    background-color: darken(@circle-color, 5%);
+  }
+  .state-circle-with-background-nohover(@circle-color) {
     background-color: @circle-color;
   }
 
   .state-circle-with-background-and-content(@circle-color) {
     .state-circle-with-background(@circle-color);
     color: black;
+  }
+  .state-circle-with-background-and-content-hover(@circle-color) {
+    .state-circle-with-background-hover(@circle-color);
+  }
+  .state-circle-with-background-and-content-nohover(@circle-color) {
+    .state-circle-with-background-nohover(@circle-color);
   }
 
   &.small {
@@ -91,9 +121,14 @@ aw-wizard-navigation-bar.vertical {
           .line(@small-dot-width, @small-dot-height, @wz-color-default);
         }
 
-        &:after {
+        .step-indicator {
           .state-circle(@small-dot-width, @small-dot-height, 0);
           .state-circle-with-background(@wz-color-default);
+        }
+
+        a:hover .step-indicator {
+          .state-circle-hover(@small-dot-width, @small-dot-height, 0);
+          .state-circle-with-background-hover(@wz-color-default);
         }
 
         div {
@@ -101,26 +136,18 @@ aw-wizard-navigation-bar.vertical {
         }
       }
 
+      li.current .step-indicator { .state-circle-with-background(@wz-color-current); }
+      li.done .step-indicator { .state-circle-with-background(@wz-color-done); }
+      li.optional .step-indicator { .state-circle-with-background(@wz-color-optional); }
+      li.editing .step-indicator { .state-circle-with-background(@wz-color-editing); }
+
+      li.current a:hover .step-indicator { .state-circle-with-background-hover(@wz-color-current); }
+      li.done a:hover .step-indicator { .state-circle-with-background-hover(@wz-color-done); }
+      li.optional a:hover .step-indicator { .state-circle-with-background-hover(@wz-color-optional); }
+      li.editing a:hover .step-indicator { .state-circle-with-background-hover(@wz-color-editing); }
+
       // default steps shouldn't change when hovered, because they aren't clickable
-      li.default a:hover {
-        color: @wz-color-current;
-      }
-
-      li.current:after {
-        .state-circle-with-background(@wz-color-current);
-      }
-
-      li.done:after {
-        .state-circle-with-background(@wz-color-done);
-      }
-
-      li.optional:after {
-        .state-circle-with-background(@wz-color-optional);
-      }
-
-      li.editing:after {
-        .state-circle-with-background(@wz-color-editing);
-      }
+      li.default a:hover .step-indicator { .state-circle-with-background-nohover(@wz-color-current); }
     }
   }
 
@@ -133,9 +160,14 @@ aw-wizard-navigation-bar.vertical {
           .line(@big-dot-width, @big-dot-height, @wz-color-default);
         }
 
-        &:after {
+        .step-indicator {
           .state-circle(@big-dot-width, @big-dot-height, 0);
           .state-circle-with-background(@wz-color-default);
+        }
+
+        a:hover .step-indicator {
+          .state-circle-hover(@big-dot-width, @big-dot-height, 0);
+          .state-circle-with-background-hover(@wz-color-default);
         }
 
         div {
@@ -143,26 +175,18 @@ aw-wizard-navigation-bar.vertical {
         }
       }
 
+      li.current .step-indicator { .state-circle-with-background(@wz-color-current); }
+      li.done .step-indicator { .state-circle-with-background(@wz-color-done); }
+      li.optional .step-indicator { .state-circle-with-background(@wz-color-optional); }
+      li.editing .step-indicator { .state-circle-with-background(@wz-color-editing); }
+
+      li.current a:hover .step-indicator { .state-circle-with-background-hover(@wz-color-current); }
+      li.done a:hover .step-indicator { .state-circle-with-background-hover(@wz-color-done); }
+      li.optional a:hover .step-indicator { .state-circle-with-background-hover(@wz-color-optional); }
+      li.editing a:hover .step-indicator { .state-circle-with-background-hover(@wz-color-editing); }
+
       // default steps shouldn't change when hovered, because they aren't clickable
-      li.default a:hover {
-        color: @wz-color-current;
-      }
-
-      li.current:after {
-        .state-circle-with-background(@wz-color-current);
-      }
-
-      li.done:after {
-        .state-circle-with-background(@wz-color-done);
-      }
-
-      li.optional:after {
-        .state-circle-with-background(@wz-color-optional);
-      }
-
-      li.editing:after {
-        .state-circle-with-background(@wz-color-editing);
-      }
+      li.default a:hover .step-indicator { .state-circle-with-background-nohover(@wz-color-current); }
     }
   }
 
@@ -175,9 +199,14 @@ aw-wizard-navigation-bar.vertical {
           .line(@big-dot-width, @big-dot-height, @wz-color-default);
         }
 
-        &:after {
+        .step-indicator {
           .state-circle(@big-dot-width, @big-dot-height, @dot-border-width);
           .state-circle-with-border(@dot-border-width, @wz-color-default);
+        }
+
+        a:hover .step-indicator {
+          .state-circle-hover(@big-dot-width, @big-dot-height, @dot-border-width);
+          .state-circle-with-border-hover(@dot-border-width, @wz-color-default);
         }
 
         div {
@@ -185,26 +214,18 @@ aw-wizard-navigation-bar.vertical {
         }
       }
 
+      li.current .step-indicator { .state-circle-with-border(@dot-border-width, @wz-color-current); }
+      li.done .step-indicator { .state-circle-with-border(@dot-border-width, @wz-color-done); }
+      li.optional .step-indicator { .state-circle-with-border(@dot-border-width, @wz-color-optional); }
+      li.editing .step-indicator { .state-circle-with-border(@dot-border-width, @wz-color-editing); }
+
+      li.current a:hover .step-indicator { .state-circle-with-border-hover(@dot-border-width, @wz-color-current); }
+      li.done a:hover .step-indicator { .state-circle-with-border-hover(@dot-border-width, @wz-color-done); }
+      li.optional a:hover .step-indicator { .state-circle-with-border-hover(@dot-border-width, @wz-color-optional); }
+      li.editing a:hover .step-indicator { .state-circle-with-border-hover(@dot-border-width, @wz-color-editing); }
+
       // default steps shouldn't change when hovered, because they aren't clickable
-      li.default a:hover {
-        color: @wz-color-current;
-      }
-
-      li.current:after {
-        .state-circle-with-border(@dot-border-width, @wz-color-current);
-      }
-
-      li.done:after {
-        .state-circle-with-border(@dot-border-width, @wz-color-done);
-      }
-
-      li.optional:after {
-        .state-circle-with-border(@dot-border-width, @wz-color-optional);
-      }
-
-      li.editing:after {
-        .state-circle-with-border(@dot-border-width, @wz-color-editing);
-      }
+      li.default a:hover .step-indicator { .state-circle-with-border-nohover(@dot-border-width, @wz-color-current); }
     }
   }
 
@@ -217,11 +238,18 @@ aw-wizard-navigation-bar.vertical {
           .line(@big-dot-width, @big-dot-height, @wz-color-default);
         }
 
-        &:after {
+        .step-indicator {
           .state-circle(@big-dot-width, @big-dot-height, 0);
           .state-circle-with-background-and-content(@wz-color-default);
 
-          content: attr(step-symbol);
+          &:before {
+            content: attr(step-symbol);
+          }
+        }
+
+        a:hover .step-indicator {
+          .state-circle-hover(@big-dot-width, @big-dot-height, 0);
+          .state-circle-with-background-and-content-hover(@wz-color-default);
         }
 
         div {
@@ -229,26 +257,18 @@ aw-wizard-navigation-bar.vertical {
         }
       }
 
+      li.current .step-indicator { .state-circle-with-background-and-content(@wz-color-current); }
+      li.done .step-indicator { .state-circle-with-background-and-content(@wz-color-done); }
+      li.optional .step-indicator { .state-circle-with-background-and-content(@wz-color-optional); }
+      li.editing .step-indicator { .state-circle-with-background-and-content(@wz-color-editing); }
+
+      li.current a:hover .step-indicator { .state-circle-with-background-and-content-hover(@wz-color-current); }
+      li.done a:hover .step-indicator { .state-circle-with-background-and-content-hover(@wz-color-done); }
+      li.optional a:hover .step-indicator { .state-circle-with-background-and-content-hover(@wz-color-optional); }
+      li.editing a:hover .step-indicator { .state-circle-with-background-and-content-hover(@wz-color-editing); }
+
       // default steps shouldn't change when hovered, because they aren't clickable
-      li.default a:hover {
-        color: @wz-color-current;
-      }
-
-      li.current:after {
-        .state-circle-with-background-and-content(@wz-color-current);
-      }
-
-      li.done:after {
-        .state-circle-with-background-and-content(@wz-color-done);
-      }
-
-      li.optional:after {
-        .state-circle-with-background-and-content(@wz-color-optional);
-      }
-
-      li.editing:after {
-        .state-circle-with-background-and-content(@wz-color-editing);
-      }
+      li.default a:hover .step-indicator { .state-circle-with-background-and-content-nohover(@wz-color-current); }
     }
   }
 
@@ -261,11 +281,18 @@ aw-wizard-navigation-bar.vertical {
           .line(@big-dot-width, @big-dot-height, @wz-color-default);
         }
 
-        &:after {
+        .step-indicator {
           .state-circle(@big-dot-width, @big-dot-height, @dot-border-width);
           .state-circle-with-border-and-content(@dot-border-width, @wz-color-default);
 
-          content: attr(step-symbol);
+          &:before {
+            content: attr(step-symbol);
+          }
+        }
+
+        a:hover .step-indicator {
+          .state-circle-hover(@big-dot-width, @big-dot-height, @dot-border-width);
+          .state-circle-with-border-and-content-hover(@dot-border-width, @wz-color-default);
         }
 
         div {
@@ -273,26 +300,18 @@ aw-wizard-navigation-bar.vertical {
         }
       }
 
+      li.current .step-indicator { .state-circle-with-border-and-content(@dot-border-width, @wz-color-current); }
+      li.done .step-indicator { .state-circle-with-border-and-content(@dot-border-width, @wz-color-done); }
+      li.optional .step-indicator { .state-circle-with-border-and-content(@dot-border-width, @wz-color-optional); }
+      li.editing .step-indicator { .state-circle-with-border-and-content(@dot-border-width, @wz-color-editing); }
+
+      li.current a:hover .step-indicator { .state-circle-with-border-and-content-hover(@dot-border-width, @wz-color-current); }
+      li.done a:hover .step-indicator { .state-circle-with-border-and-content-hover(@dot-border-width, @wz-color-done); }
+      li.optional a:hover .step-indicator { .state-circle-with-border-and-content-hover(@dot-border-width, @wz-color-optional); }
+      li.editing a:hover .step-indicator { .state-circle-with-border-and-content-hover(@dot-border-width, @wz-color-editing); }
+
       // default steps shouldn't change when hovered, because they aren't clickable
-      li.default a:hover {
-        color: @wz-color-current;
-      }
-
-      li.current:after {
-        .state-circle-with-border-and-content(@dot-border-width, @wz-color-current);
-      }
-
-      li.done:after {
-        .state-circle-with-border-and-content(@dot-border-width, @wz-color-done);
-      }
-
-      li.optional:after {
-        .state-circle-with-border-and-content(@dot-border-width, @wz-color-optional);
-      }
-
-      li.editing:after {
-        .state-circle-with-border-and-content(@dot-border-width, @wz-color-editing);
-      }
+      li.default a:hover .step-indicator { .state-circle-with-border-and-content-nohover(@dot-border-width, @wz-color-current); }
     }
   }
 
@@ -320,27 +339,36 @@ aw-wizard-navigation-bar.vertical {
         padding-bottom: @distance-between-steps;
       }
 
-      div {
-        display: flex;
-        flex-direction: row;
-        align-items: center;
+      a {
+        cursor: pointer;
+      }
 
-        a {
-          color: @wz-color-current;
-          margin-left: @text-margin-left;
-          line-height: @text-height;
-          font-size: @text-height;
-          text-decoration: none;
-          text-transform: uppercase;
-          text-align: left;
-          font-weight: bold;
-          transition: 0.25s;
-          cursor: pointer;
+      .label {
+        margin-left: @text-margin-left;
+        color: @wz-color-current;
+        line-height: @text-height;
+        font-size: @text-height;
+        text-decoration: none;
+        text-transform: uppercase;
+        text-align: left;
+        font-weight: bold;
+        transition: 0.25s;
+      }
+    }
 
-          &:hover {
-            color: darken(@wz-color-current, 20%);
-          }
-        }
+    li a:hover .label {
+      color: darken(@wz-color-current, 20%);
+    }
+
+    // default steps shouldn't change when hovered, because they aren't clickable
+    li.default {
+
+      a {
+        cursor: auto;
+      }
+
+      .label {
+        color: @wz-color-current;
       }
     }
 
@@ -349,6 +377,3 @@ aw-wizard-navigation-bar.vertical {
     }
   }
 }
-
-
-

--- a/src/components/wizard-step.component.ts
+++ b/src/components/wizard-step.component.ts
@@ -6,7 +6,7 @@ import {WizardStep} from '../util/wizard-step.interface';
  *
  * ### Syntax
  *
- * With `stepTitle` input:
+ * With `stepTitle` and `navigationSymbol` inputs:
  *
  * ```html
  * <aw-wizard-step [stepTitle]="step title" [navigationSymbol]="{ symbol: 'symbol', fontFamily: 'font-family' }"
@@ -15,13 +15,16 @@ import {WizardStep} from '../util/wizard-step.interface';
  * </aw-wizard-step>
  * ```
  *
- * With `awWizardStepTitle` directive:
+ * With `awWizardStepTitle` and `awWizardStepSymbol` directives:
  *
  * ```html
- * <aw-wizard-step [navigationSymbol]="{ symbol: 'symbol', fontFamily: 'font-family' }"
+ * <aw-wizard-step"
  *    [canExit]="deciding function" (stepEnter)="enter function" (stepExit)="exit function">
  *    <ng-template awWizardStepTitle>
  *        step title
+ *    </ng-template>
+ *    <ng-template awWizardStepSymbol>
+ *        symbol
  *    </ng-template>
  *    ...
  * </aw-wizard-step>
@@ -29,7 +32,7 @@ import {WizardStep} from '../util/wizard-step.interface';
  *
  * ### Example
  *
- * With `stepTitle` input:
+ * With `stepTitle` and `navigationSymbol` inputs:
  *
  * ```html
  * <aw-wizard-step stepTitle="Address information" [navigationSymbol]="{ symbol: '&#xf1ba;', fontFamily: 'FontAwesome' }">
@@ -37,12 +40,15 @@ import {WizardStep} from '../util/wizard-step.interface';
  * </aw-wizard-step>
  * ```
  *
- * With `awWizardStepTitle` directive:
+ * With `awWizardStepTitle` and `awWizardStepSymbol` directives:
  *
  * ```html
- * <aw-wizard-step [navigationSymbol]="{ symbol: '&#xf1ba;', fontFamily: 'FontAwesome' }">
+ * <aw-wizard-step>
  *    <ng-template awWizardStepTitle>
  *        Address information
+ *    </ng-template>
+ *    <ng-template awWizardStepSymbol>
+ *        <i class="fa fa-taxi"></i>
  *    </ng-template>
  * </aw-wizard-step>
  * ```

--- a/src/directives/wizard-step-symbol.directive.spec.ts
+++ b/src/directives/wizard-step-symbol.directive.spec.ts
@@ -1,0 +1,54 @@
+import {ViewChild, Component} from '@angular/core';
+import {TestBed, async, ComponentFixture} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+
+import {WizardComponent} from '../components/wizard.component';
+import {ArchwizardModule} from '../archwizard.module';
+
+
+@Component({
+  selector: 'aw-test-wizard',
+  template: `
+    <aw-wizard>
+      <aw-wizard-step stepTitle='Step A'>
+        <ng-template awWizardStepSymbol>A</ng-template>
+        Step A content
+      </aw-wizard-step>
+      <aw-wizard-completion-step stepTitle='Step B'>
+        <ng-template awWizardStepSymbol>B</ng-template>
+        Step B content
+      </aw-wizard-completion-step>
+    </aw-wizard>
+  `
+})
+class WizardTestComponent {
+  @ViewChild(WizardComponent)
+  public wizard: WizardComponent;
+}
+
+describe('WizardStepSymbolDirective', () => {
+  let wizardTest: WizardTestComponent;
+  let wizardTestFixture: ComponentFixture<WizardTestComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [WizardTestComponent],
+      imports: [ArchwizardModule]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    wizardTestFixture = TestBed.createComponent(WizardTestComponent);
+    wizardTestFixture.detectChanges();
+
+    wizardTest = wizardTestFixture.componentInstance;
+  });
+
+  it('should create an instance', () => {
+    let navigationSymbols = wizardTestFixture.debugElement.queryAll(By.css('aw-wizard-navigation-bar ul li .step-indicator'));
+
+    expect(navigationSymbols.length).toBe(2);
+    expect(navigationSymbols[0].nativeElement.innerText).toBe('A');
+    expect(navigationSymbols[1].nativeElement.innerText).toBe('B');
+  });
+});

--- a/src/directives/wizard-step-symbol.directive.ts
+++ b/src/directives/wizard-step-symbol.directive.ts
@@ -1,0 +1,25 @@
+import {Directive, TemplateRef} from '@angular/core';
+
+/**
+ * The `awWizardStepSymbol` directive can be used as an alternative to the `navigationSymbol` input of a [[WizardStep]]
+ * to define the step symbol inside the navigation bar.  This way step symbol may contain arbitrary content.
+ *
+ * ### Syntax
+ *
+ * ```html
+ * <ng-template awWizardStepSymbol>
+ *     ...
+ * </ng-template>
+ * ```
+ */
+@Directive({
+  selector: 'ng-template[awStepSymbol], ng-template[awWizardStepSymbol]'
+})
+export class WizardStepSymbolDirective {
+  /**
+   * Constructor
+   *
+   * @param templateRef A reference to the content of the `ng-template` that contains this [[WizardStepSymbolDirective]]
+   */
+  constructor(public templateRef: TemplateRef<any>) { }
+}

--- a/src/directives/wizard-step.directive.ts
+++ b/src/directives/wizard-step.directive.ts
@@ -6,7 +6,7 @@ import {WizardStep} from '../util/wizard-step.interface';
  *
  * ### Syntax
  *
- * With `stepTitle` input:
+ * With `stepTitle` and `navigationSymbol` inputs:
  *
  * ```html
  * <div awWizardStep [stepTitle]="step title" [navigationSymbol]="{ symbol: 'symbol', fontFamily: 'font-family' }"
@@ -15,13 +15,15 @@ import {WizardStep} from '../util/wizard-step.interface';
  * </div>
  * ```
  *
- * With `awWizardStepTitle` directive:
+ * With `awWizardStepTitle` and `awWizardStepSymbol` directives:
  *
  * ```html
- * <div awWizardStep [navigationSymbol]="{ symbol: 'symbol', fontFamily: 'font-family' }"
- *    [canExit]="deciding function" (stepEnter)="enter function" (stepExit)="exit function">
+ * <div awWizardStep [canExit]="deciding function" (stepEnter)="enter function" (stepExit)="exit function">
  *    <ng-template awWizardStepTitle>
  *        step title
+ *    </ng-template>
+ *    <ng-template awWizardStepSymbol>
+ *        symbol
  *    </ng-template>
  *    ...
  * </div>
@@ -29,7 +31,7 @@ import {WizardStep} from '../util/wizard-step.interface';
  *
  * ### Example
  *
- * With `stepTitle` input:
+ * With `stepTitle` and `navigationSymbol` inputs:
  *
  * ```html
  * <div awWizardStep stepTitle="Address information" [navigationSymbol]="{ symbol: '&#xf1ba;', fontFamily: 'FontAwesome' }">
@@ -37,12 +39,15 @@ import {WizardStep} from '../util/wizard-step.interface';
  * </div>
  * ```
  *
- * With `awWizardStepTitle` directive:
+ * With `awWizardStepTitle` and `awWizardStepSymbol` directives:
  *
  * ```html
- * <div awWizardStep [navigationSymbol]="{ symbol: '&#xf1ba;', fontFamily: 'FontAwesome' }">
+ * <div awWizardStep>
  *    <ng-template awWizardStepTitle>
  *        Address information
+ *    </ng-template>
+ *    <ng-template awWizardStepSymbol>
+ *        <i class="fa fa-taxi"></i>
  *    </ng-template>
  * </div>
  * ```

--- a/src/util/wizard-step.interface.ts
+++ b/src/util/wizard-step.interface.ts
@@ -3,6 +3,7 @@ import {WizardStepTitleDirective} from '../directives/wizard-step-title.directiv
 import {ContentChild, EventEmitter, HostBinding, Input, Output} from '@angular/core';
 import {isBoolean} from 'util';
 import {NavigationSymbol} from './navigation-symbol.interface';
+import {WizardStepSymbolDirective} from '../directives/wizard-step-symbol.directive';
 
 /**
  * Basic functionality every type of wizard step needs to provide
@@ -19,6 +20,13 @@ export abstract class WizardStep {
   public stepTitleTemplate: WizardStepTitleDirective;
 
   /**
+   * A step symbol property that, if defined, overrides `navigationSymbol`.
+   * Allows to display arbitrary content as a step symbol instead of plain text.
+   */
+  @ContentChild(WizardStepSymbolDirective)
+  public stepSymbolTemplate: WizardStepSymbolDirective;
+
+  /**
    * A step id, unique to the step
    */
   @Input()
@@ -33,6 +41,7 @@ export abstract class WizardStep {
 
   /**
    * A symbol property, which contains an optional symbol for the step inside the navigation bar.
+   * Takes effect when `stepSymbolTemplate` is not defined or null.
    */
   @Input()
   public navigationSymbol: NavigationSymbol = { symbol: '' };


### PR DESCRIPTION
This PR provides ability to define step navigation symbol in the form of Angular template.
    
For example:
    
```
<div awWizardStep>
   <ng-template awWizardStepTitle>
       Address information
   </ng-template>
   <ng-template awWizardStepSymbol>
       <i class="fa fa-taxi"></i>
   </ng-template>
</div>
```

TODO:
- Document in the main README.md
- Add an example in the [demo app](https://github.com/madoar/angular-archwizard-demo/)

Based on the `clickable-step-indicators` branch, see https://github.com/madoar/angular-archwizard/pull/129.