### PR TITLE
Automatically calculate the code coverage during npm/ng test

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -21,7 +21,8 @@
           "options": {
             "main": "src/test.ts",
             "tsConfig": "tsconfig.spec.json",
-            "karmaConfig": "karma.conf.js"
+            "karmaConfig": "karma.conf.js",
+            "codeCoverage": true
           }
         },
         "lint": {


### PR DESCRIPTION
This PR adds the calculation of the code coverage to npm/ng test