### PR TITLE
Explicitly exporting each component in the base index.ts file

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,8 @@
-export * from './lib/components';
+export { WizardCompletionStepComponent } from './lib/components/wizard-completion-step.component';
+export { WizardNavigationBarComponent } from './lib/components/wizard-navigation-bar.component';
+export { WizardStepComponent } from './lib/components/wizard-step.component';
+export { WizardComponent } from './lib/components/wizard.component';
+
 export * from './lib/directives';
 export * from './lib/navigation';
 export * from './lib/util';


### PR DESCRIPTION
Using barrel exports with ng-packagr can have strange side-effects when using the package in an AOT production build. 

This is for issue #131 which I discovered would be fixed by explicitly exporting each component in the index.ts

Since it is impossible to currently write unit tests for Angular AOT builds, I created a small Angular application that used the angular-archwizard package with my changes and verified that the reference to the @ViewChild() component is defined with an AOT build served with Express.js.