### PR TITLE
In tslint.json, set "no-use-before-declare" to false to prevent linting error

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -73,7 +73,7 @@
     "no-trailing-whitespace": true,
     "no-unnecessary-initializer": true,
     "no-unused-expression": true,
-    "no-use-before-declare": true,
+    "no-use-before-declare": false,
     "no-var-keyword": true,
     "object-literal-sort-keys": false,
     "one-line": [


### PR DESCRIPTION
```
$ ng lint
Linting "angular-archwizard"...

ERROR: C:/angular-archwizard/src/lib/directives/wizard-step.directive.spec.ts[27, 31]: variable 'WizardStepTestComponent' used before declaration

Lint errors found in the listed files.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

The use of no-use-before-declare rule is now officially discouraged:
- https://palantir.github.io/tslint/rules/no-use-before-declare/
- https://stackoverflow.com/questions/54000528/angular2-tslint-show-variable-xxx-used-before-declaration-when-using-forwardr