### PR TITLE
Rename BaseNavigationMode.checkReset to ensureCanReset

### DIFF
--- a/src/lib/navigation/base-navigation-mode.interface.ts
+++ b/src/lib/navigation/base-navigation-mode.interface.ts
@@ -139,9 +139,7 @@ export abstract class BaseNavigationMode implements NavigationMode {
    * In addition the whole wizard is set as incomplete.
    */
   public reset(): void {
-    if (!this.checkReset()) {
-      return;
-    }
+    this.ensureCanReset();
 
     // reset the step internal state
     this.wizardState.wizardSteps.forEach(step => {
@@ -158,20 +156,17 @@ export abstract class BaseNavigationMode implements NavigationMode {
   /**
    * Checks if wizard configuration allows to perform reset.
    *
-   * A check failure can be indicated either by `false` return value or by throwing
-   * an `Error` with the message discribing the discovered misconfiguration issue.
+   * A check failure is indicated by throwing an `Error` with the message discribing the discovered misconfiguration issue.
    *
    * Can include additional checks in particular navigation mode implementations.
    *
-   * @returns True if wizard configuration is correct and reset can be performed, false otherwise
    * @throws An `Error` is thrown, if a micconfiguration issue is discovered.
    */
-  protected checkReset(): boolean {
+  protected ensureCanReset(): void {
     // the wizard doesn't contain a step with the default step index
     if (!this.wizardState.hasStep(this.wizardState.defaultStepIndex)) {
       throw new Error(`The wizard doesn't contain a step with index ${this.wizardState.defaultStepIndex}`);
     }
-    return true;
   }
 
   /**

--- a/src/lib/navigation/semi-strict-navigation-mode.ts
+++ b/src/lib/navigation/semi-strict-navigation-mode.ts
@@ -29,17 +29,13 @@ export class SemiStrictNavigationMode extends BaseNavigationMode {
   /**
    * @inheritDoc
    */
-  protected checkReset(): boolean {
-    if (!super.checkReset()) {
-      return false;
-    }
+  protected ensureCanReset(): void {
+    super.ensureCanReset();
 
     // the default step is a completion step and the wizard contains more than one step
     const defaultCompletionStep = this.wizardState.getStepAtIndex(this.wizardState.defaultStepIndex) instanceof WizardCompletionStep;
     if (defaultCompletionStep && this.wizardState.wizardSteps.length !== 1) {
       throw new Error(`The default step index ${this.wizardState.defaultStepIndex} references a completion step`);
     }
-
-    return true;
   }
 }

--- a/src/lib/navigation/strict-navigation-mode.ts
+++ b/src/lib/navigation/strict-navigation-mode.ts
@@ -42,10 +42,8 @@ export class StrictNavigationMode extends BaseNavigationMode {
   /**
    * @inheritDoc
    */
-  protected checkReset(): boolean {
-    if (!super.checkReset()) {
-      return false;
-    }
+  protected ensureCanReset(): void {
+    super.ensureCanReset();
 
     // at least one step is before the default step, that is not optional
     const illegalDefaultStep = this.wizardState.wizardSteps
@@ -54,7 +52,5 @@ export class StrictNavigationMode extends BaseNavigationMode {
     if (illegalDefaultStep) {
       throw new Error(`The default step index ${this.wizardState.defaultStepIndex} is located after a non optional step`);
     }
-
-    return true;
   }
 }


### PR DESCRIPTION
- Rename `checkReset` to `ensureCanReset`
- Use `void` return value instead of `boolean`

An error is indicated by an exception.

See discussion: https://github.com/madoar/angular-archwizard/pull/166#discussion_r226856010

<a href="https://gitpod.io/#https://github.com/madoar/angular-archwizard/pull/206"><img src="https://gitpod.io/api/apps/github/pbs/github.com/earshinov/angular-archwizard.git/419eb44efbddd2b6b6200bd8b95740e19d8d5e11.svg" /></a>

