### PR TITLE
Declare compatibility with Angular 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,12 +20,15 @@
     "angular5",
     "angular6",
     "angular7",
+    "angular8",
     "angular 5",
     "angular 6",
     "angular 7",
+    "angular 8",
     "ng5",
     "ng6",
     "ng7",
+    "ng8",
     "ngx",
     "typescript",
     "wizard",
@@ -81,6 +84,6 @@
     "zone.js": "~0.8.29"
   },
   "peerDependencies": {
-    "@angular/common": "5.x, 6.x, 7.x"
+    "@angular/common": ">= 5"
   }
 }


### PR DESCRIPTION
Compatibility range declared in `package.json` is now open-ended (>= 5), corresponding to what is written in README.md.

We have migrated our project where we are using angular-archwizard to Angular 8, and angular-archwizard continued to work just as fine.

<a href="https://gitpod.io/#https://github.com/madoar/angular-archwizard/pull/220"><img src="https://gitpod.io/api/apps/github/pbs/github.com/earshinov/angular-archwizard.git/21a1bbabf5e0cb78224f8072a47cb696069d1978.svg" /></a>

