### PR TITLE
Track step "editing" state with a separate `WizardStep.editing` flag

### DIFF
--- a/src/css/wizard-navigation-bar.scss
+++ b/src/css/wizard-navigation-bar.scss
@@ -160,8 +160,7 @@ $wz-param-indicator-color: null !global;
       $wz-param-indicator-color: $wz-color-current !global;
       @content;
     }
-    &.current.done .step-indicator,
-    &.current.completed .step-indicator {
+    &.editing .step-indicator {
       $wz-param-indicator-state: 'default' !global;
       $wz-param-indicator-color: $wz-color-editing !global;
       @content;
@@ -190,7 +189,7 @@ $wz-param-indicator-color: null !global;
       $wz-param-indicator-color: $wz-color-current !global;
       @content;
     }
-    &.navigable.current.done, &.navigable.current.completed {
+    &.navigable.editing {
       a:hover .step-indicator {
         $wz-param-indicator-state: 'hover' !global;
         $wz-param-indicator-color: $wz-color-editing !global;

--- a/src/lib/components/wizard-navigation-bar.component.html
+++ b/src/lib/components/wizard-navigation-bar.component.html
@@ -2,6 +2,7 @@
   <li [attr.id]="step.stepId" *ngFor="let step of wizardSteps"
       [ngClass]="{
         current: isCurrent(step),
+        editing: isEditing(step),
         done: isDone(step),
         optional: isOptional(step),
         completed: isCompleted(step),

--- a/src/lib/components/wizard-navigation-bar.component.ts
+++ b/src/lib/components/wizard-navigation-bar.component.ts
@@ -71,6 +71,16 @@ export class WizardNavigationBarComponent {
   }
 
   /**
+   * Checks, whether a [[WizardStep]] can be marked as `editing` in the navigation bar
+   *
+   * @param wizardStep The wizard step to be checked
+   * @returns True if the step can be marked as `editing`
+   */
+  public isEditing(wizardStep: WizardStep): boolean {
+    return wizardStep.editing;
+  }
+
+  /**
    * Checks, whether a [[WizardStep]] can be marked as `done` in the navigation bar
    *
    * @param wizardStep The wizard step to be checked

--- a/src/lib/directives/reset-wizard.directive.spec.ts
+++ b/src/lib/directives/reset-wizard.directive.spec.ts
@@ -71,14 +71,14 @@ describe('ResetWizardDirective', () => {
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 1, [0], false);
+    checkWizardState(wizard, 1, false, [0], false);
     expect(wizardTest.eventLog).toEqual([]);
 
     resetButtonEls[0].nativeElement.click();
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 0, [], false);
+    checkWizardState(wizard, 0, false, [], false);
     expect(wizardTest.eventLog).toEqual([]);
   }));
 
@@ -89,14 +89,14 @@ describe('ResetWizardDirective', () => {
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 1, [0], false);
+    checkWizardState(wizard, 1, false, [0], false);
     expect(wizardTest.eventLog).toEqual([]);
 
     resetButtonEls[1].nativeElement.click();
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 0, [], false);
+    checkWizardState(wizard, 0, false, [], false);
     expect(wizardTest.eventLog).toEqual(['Cleanup done!']);
   }));
 });

--- a/src/lib/directives/reset-wizard.directive.spec.ts
+++ b/src/lib/directives/reset-wizard.directive.spec.ts
@@ -5,6 +5,7 @@ import {ArchwizardModule} from '../archwizard.module';
 import {NavigationMode} from '../navigation/navigation-mode.interface';
 import {ResetWizardDirective} from './reset-wizard.directive';
 import {WizardComponent} from '../components/wizard.component';
+import { checkWizardState } from '../util/test-utils';
 
 @Component({
   selector: 'aw-test-wizard',
@@ -70,20 +71,14 @@ describe('ResetWizardDirective', () => {
     tick();
     wizardTestFixture.detectChanges();
 
-    expect(wizard.getStepAtIndex(0).selected).toBe(false);
-    expect(wizard.getStepAtIndex(0).completed).toBe(true);
-    expect(wizard.getStepAtIndex(1).selected).toBe(true);
-    expect(wizard.getStepAtIndex(1).completed).toBe(false);
+    checkWizardState(wizard, 1, [0], false);
     expect(wizardTest.eventLog).toEqual([]);
 
     resetButtonEls[0].nativeElement.click();
     tick();
     wizardTestFixture.detectChanges();
 
-    expect(wizard.getStepAtIndex(0).selected).toBe(true);
-    expect(wizard.getStepAtIndex(0).completed).toBe(false);
-    expect(wizard.getStepAtIndex(1).selected).toBe(false);
-    expect(wizard.getStepAtIndex(1).completed).toBe(false);
+    checkWizardState(wizard, 0, [], false);
     expect(wizardTest.eventLog).toEqual([]);
   }));
 
@@ -94,20 +89,14 @@ describe('ResetWizardDirective', () => {
     tick();
     wizardTestFixture.detectChanges();
 
-    expect(wizard.getStepAtIndex(0).selected).toBe(false);
-    expect(wizard.getStepAtIndex(0).completed).toBe(true);
-    expect(wizard.getStepAtIndex(1).selected).toBe(true);
-    expect(wizard.getStepAtIndex(1).completed).toBe(false);
+    checkWizardState(wizard, 1, [0], false);
     expect(wizardTest.eventLog).toEqual([]);
 
     resetButtonEls[1].nativeElement.click();
     tick();
     wizardTestFixture.detectChanges();
 
-    expect(wizard.getStepAtIndex(0).selected).toBe(true);
-    expect(wizard.getStepAtIndex(0).completed).toBe(false);
-    expect(wizard.getStepAtIndex(1).selected).toBe(false);
-    expect(wizard.getStepAtIndex(1).completed).toBe(false);
+    checkWizardState(wizard, 0, [], false);
     expect(wizardTest.eventLog).toEqual(['Cleanup done!']);
   }));
 });

--- a/src/lib/navigation/base-navigation-mode.interface.ts
+++ b/src/lib/navigation/base-navigation-mode.interface.ts
@@ -108,13 +108,20 @@ export abstract class BaseNavigationMode implements NavigationMode {
         // leave current step
         wizard.currentStep.completed = true;
         wizard.currentStep.exit(movingDirection);
+        wizard.currentStep.editing = false;
         wizard.currentStep.selected = false;
 
         this.transition(wizard, destinationIndex);
 
+        // remember if the next step is already completed before entering it to properly set `editing` flag
+        const wasCompleted = wizard.completed || wizard.currentStep.completed;
+
         // go to next step
         wizard.currentStep.enter(movingDirection);
         wizard.currentStep.selected = true;
+        if (wasCompleted) {
+          wizard.currentStep.editing = true;
+        }
 
         /* istanbul ignore if */
         if (postFinalize) {
@@ -160,6 +167,7 @@ export abstract class BaseNavigationMode implements NavigationMode {
     wizard.wizardSteps.forEach(step => {
       step.completed = false;
       step.selected = false;
+      step.editing = false;
     });
 
     // set the first step as the current step

--- a/src/lib/navigation/wizard-navigation-allow-forward.spec.ts
+++ b/src/lib/navigation/wizard-navigation-allow-forward.spec.ts
@@ -55,19 +55,19 @@ describe('Wizard navigation with navigateForward=allow', () => {
   }));
 
   it('should go to step', fakeAsync(() => {
-    checkWizardState(wizard, 0, [], false);
+    checkWizardState(wizard, 0, false, [], false);
 
     wizard.goToStep(1);
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 1, [0], false);
+    checkWizardState(wizard, 1, false, [0], false);
 
     wizard.goToStep(2);
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 2, [0, 1], false);
+    checkWizardState(wizard, 2, false, [0, 1], false);
 
     wizard.goToStep(0);
     tick();
@@ -75,25 +75,25 @@ describe('Wizard navigation with navigateForward=allow', () => {
 
     // If forward navigation is allowed, visited steps after
     // the selected step are still considered completed
-    checkWizardState(wizard, 0, [0, 1, 2], true);
+    checkWizardState(wizard, 0, true, [0, 1, 2], true);
 
     wizard.goToStep(1);
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 1, [0, 1, 2], true);
+    checkWizardState(wizard, 1, true, [0, 1, 2], true);
 
     wizard.goToStep(2);
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 2, [0, 1, 2], true);
+    checkWizardState(wizard, 2, true, [0, 1, 2], true);
 
     wizard.goToStep(1);
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 1, [0, 1, 2], true);
+    checkWizardState(wizard, 1, true, [0, 1, 2], true);
   }));
 
   it('should go to next step', fakeAsync(() => {
@@ -101,17 +101,17 @@ describe('Wizard navigation with navigateForward=allow', () => {
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 1, [0], false);
+    checkWizardState(wizard, 1, false, [0], false);
   }));
 
   it('should go to previous step', fakeAsync(() => {
-    checkWizardState(wizard, 0, [], false);
+    checkWizardState(wizard, 0, false, [], false);
 
     wizard.goToStep(1);
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 1, [0], false);
+    checkWizardState(wizard, 1, false, [0], false);
 
     wizard.goToPreviousStep();
     tick();
@@ -119,7 +119,7 @@ describe('Wizard navigation with navigateForward=allow', () => {
 
     // If forward navigation is allowed, visited steps after
     // the selected step are still considered completed
-    checkWizardState(wizard, 0, [0, 1], false);
+    checkWizardState(wizard, 0, true, [0, 1], false);
   }));
 
   it('should stay at the current step', fakeAsync(() => {
@@ -129,19 +129,19 @@ describe('Wizard navigation with navigateForward=allow', () => {
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 0, [], false);
+    checkWizardState(wizard, 0, false, [], false);
 
     wizard.goToStep(-1);
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 0, [], false);
+    checkWizardState(wizard, 0, false, [], false);
 
     wizard.goToStep(0);
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 0, [0], false);
+    checkWizardState(wizard, 0, true, [0], false);
   }));
 
   it('should reset the wizard correctly', fakeAsync(() => {
@@ -153,26 +153,26 @@ describe('Wizard navigation with navigateForward=allow', () => {
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 2, [0, 1], false);
+    checkWizardState(wizard, 2, false, [0, 1], false);
 
     wizard.reset();
 
-    checkWizardState(wizard, 0, [], false);
+    checkWizardState(wizard, 0, false, [], false);
 
     wizard.defaultStepIndex = -1;
     expect(() => wizard.reset())
       .toThrow(new Error(`The wizard doesn't contain a step with index -1`));
 
-    checkWizardState(wizard, 0, [], false);
+    checkWizardState(wizard, 0, false, [], false);
 
     wizard.defaultStepIndex = 1;
     wizard.reset();
 
-    checkWizardState(wizard, 1, [], false);
+    checkWizardState(wizard, 1, false, [], false);
 
     wizard.defaultStepIndex = 2;
     wizard.reset();
 
-    checkWizardState(wizard, 2, [], false);
+    checkWizardState(wizard, 2, false, [], false);
   }));
 });

--- a/src/lib/navigation/wizard-navigation-with-completion-step.spec.ts
+++ b/src/lib/navigation/wizard-navigation-with-completion-step.spec.ts
@@ -55,13 +55,13 @@ describe('Wizard navigation with completion step', () => {
   }));
 
   it('should go to step', fakeAsync(() => {
-    checkWizardState(wizard, 0, [], false);
+    checkWizardState(wizard, 0, false, [], false);
 
     wizard.goToStep(1);
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 1, [0], false);
+    checkWizardState(wizard, 1, false, [0], false);
 
     wizard.goToStep(2);
     tick();
@@ -69,19 +69,19 @@ describe('Wizard navigation with completion step', () => {
 
     // Completion step is marked completed right after being navigated to,
     // and marks the whole wizard completed as well.
-    checkWizardState(wizard, 2, [0, 1, 2], true);
+    checkWizardState(wizard, 2, false, [0, 1, 2], true);
 
     wizard.goToStep(0);
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 0, [0], false);
+    checkWizardState(wizard, 0, true, [0], false);
 
     wizard.goToStep(1);
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 1, [0], false);
+    checkWizardState(wizard, 1, false, [0], false);
 
     wizard.goToStep(2);
     tick();
@@ -89,13 +89,13 @@ describe('Wizard navigation with completion step', () => {
 
     // Completion step is marked completed right after being navigated to,
     // and marks the whole wizard completed as well.
-    checkWizardState(wizard, 2, [0, 1, 2], true);
+    checkWizardState(wizard, 2, false, [0, 1, 2], true);
 
     wizard.goToStep(1);
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 1, [0, 1], false);
+    checkWizardState(wizard, 1, true, [0, 1], false);
   }));
 
   it('should go to next step', fakeAsync(() => {
@@ -103,23 +103,23 @@ describe('Wizard navigation with completion step', () => {
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 1, [0], false);
+    checkWizardState(wizard, 1, false, [0], false);
   }));
 
   it('should go to previous step', fakeAsync(() => {
-    checkWizardState(wizard, 0, [], false);
+    checkWizardState(wizard, 0, false, [], false);
 
     wizard.goToStep(1);
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 1, [0], false);
+    checkWizardState(wizard, 1, false, [0], false);
 
     wizard.goToPreviousStep();
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 0, [0], false);
+    checkWizardState(wizard, 0, true, [0], false);
   }));
 
   it('should stay at the current step', fakeAsync(() => {
@@ -129,19 +129,19 @@ describe('Wizard navigation with completion step', () => {
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 0, [], false);
+    checkWizardState(wizard, 0, false, [], false);
 
     wizard.goToStep(-1);
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 0, [], false);
+    checkWizardState(wizard, 0, false, [], false);
 
     wizard.goToStep(0);
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 0, [0], false);
+    checkWizardState(wizard, 0, true, [0], false);
   }));
 
   it('should reset the wizard correctly', fakeAsync(() => {
@@ -155,27 +155,27 @@ describe('Wizard navigation with completion step', () => {
 
     // Completion step is marked completed right after being navigated to,
     // and marks the whole wizard completed as well.
-    checkWizardState(wizard, 2, [0, 1, 2], true);
+    checkWizardState(wizard, 2, false, [0, 1, 2], true);
 
     wizard.reset();
 
-    checkWizardState(wizard, 0, [], false);
+    checkWizardState(wizard, 0, false, [], false);
 
     wizard.defaultStepIndex = -1;
     expect(() => wizard.reset())
       .toThrow(new Error(`The wizard doesn't contain a step with index -1`));
 
-    checkWizardState(wizard, 0, [], false);
+    checkWizardState(wizard, 0, false, [], false);
 
     wizard.defaultStepIndex = 1;
     wizard.reset();
 
-    checkWizardState(wizard, 1, [], false);
+    checkWizardState(wizard, 1, false, [], false);
 
     wizard.defaultStepIndex = 2;
     expect(() => wizard.reset())
       .toThrow(new Error(`The default step index 2 references a completion step`));
 
-    checkWizardState(wizard, 1, [], false);
+    checkWizardState(wizard, 1, false, [], false);
   }));
 });

--- a/src/lib/navigation/wizard-navigation-with-optional-step.spec.ts
+++ b/src/lib/navigation/wizard-navigation-with-optional-step.spec.ts
@@ -55,43 +55,43 @@ describe('Wizard navigation with optional step', () => {
   }));
 
   it('should go to step', fakeAsync(() => {
-    checkWizardState(wizard, 0, [], false);
+    checkWizardState(wizard, 0, false, [], false);
 
     wizard.goToStep(1);
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 1, [0], false);
+    checkWizardState(wizard, 1, false, [0], false);
 
     wizard.goToStep(2);
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 2, [0, 1], false);
+    checkWizardState(wizard, 2, false, [0, 1], false);
 
     wizard.goToStep(0);
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 0, [0], false);
+    checkWizardState(wizard, 0, true, [0], false);
 
     wizard.goToStep(1);
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 1, [0], false);
+    checkWizardState(wizard, 1, false, [0], false);
 
     wizard.goToStep(2);
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 2, [0, 1], false);
+    checkWizardState(wizard, 2, false, [0, 1], false);
 
     wizard.goToStep(1);
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 1, [0, 1], false);
+    checkWizardState(wizard, 1, true, [0, 1], false);
   }));
 
   it('should go to next step', fakeAsync(() => {
@@ -99,23 +99,23 @@ describe('Wizard navigation with optional step', () => {
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 1, [0], false);
+    checkWizardState(wizard, 1, false, [0], false);
   }));
 
   it('should go to previous step', fakeAsync(() => {
-    checkWizardState(wizard, 0, [], false);
+    checkWizardState(wizard, 0, false, [], false);
 
     wizard.goToStep(1);
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 1, [0], false);
+    checkWizardState(wizard, 1, false, [0], false);
 
     wizard.goToPreviousStep();
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 0, [0], false);
+    checkWizardState(wizard, 0, true, [0], false);
   }));
 
   it('should stay at the current step', fakeAsync(() => {
@@ -125,19 +125,19 @@ describe('Wizard navigation with optional step', () => {
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 0, [], false);
+    checkWizardState(wizard, 0, false, [], false);
 
     wizard.goToStep(-1);
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 0, [], false);
+    checkWizardState(wizard, 0, false, [], false);
 
     wizard.goToStep(0);
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 0, [0], false);
+    checkWizardState(wizard, 0, true, [0], false);
   }));
 
   it('should reset the wizard correctly', fakeAsync(() => {
@@ -149,26 +149,26 @@ describe('Wizard navigation with optional step', () => {
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 2, [0, 1], false);
+    checkWizardState(wizard, 2, false, [0, 1], false);
 
     wizard.reset();
 
-    checkWizardState(wizard, 0, [], false);
+    checkWizardState(wizard, 0, false, [], false);
 
     wizard.defaultStepIndex = -1;
     expect(() => wizard.reset())
       .toThrow(new Error(`The wizard doesn't contain a step with index -1`));
 
-    checkWizardState(wizard, 0, [], false);
+    checkWizardState(wizard, 0, false, [], false);
 
     wizard.defaultStepIndex = 1;
     wizard.reset();
 
-    checkWizardState(wizard, 1, [], false);
+    checkWizardState(wizard, 1, false, [], false);
 
     wizard.defaultStepIndex = 2;
     wizard.reset();
 
-    checkWizardState(wizard, 2, [], false);
+    checkWizardState(wizard, 2, false, [], false);
   }));
 });

--- a/src/lib/navigation/wizard-navigation.spec.ts
+++ b/src/lib/navigation/wizard-navigation.spec.ts
@@ -55,43 +55,43 @@ describe('Wizard navigation', () => {
   }));
 
   it('should go to step', fakeAsync(() => {
-    checkWizardState(wizard, 0, [], false);
+    checkWizardState(wizard, 0, false, [], false);
 
     wizard.goToStep(1);
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 1, [0], false);
+    checkWizardState(wizard, 1, false, [0], false);
 
     wizard.goToStep(2);
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 2, [0, 1], false);
+    checkWizardState(wizard, 2, false, [0, 1], false);
 
     wizard.goToStep(0);
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 0, [0], false);
+    checkWizardState(wizard, 0, true, [0], false);
 
     wizard.goToStep(1);
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 1, [0], false);
+    checkWizardState(wizard, 1, false, [0], false);
 
     wizard.goToStep(2);
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 2, [0, 1], false);
+    checkWizardState(wizard, 2, false, [0, 1], false);
 
     wizard.goToStep(1);
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 1, [0, 1], false);
+    checkWizardState(wizard, 1, true, [0, 1], false);
   }));
 
   it('should go to next step', fakeAsync(() => {
@@ -99,23 +99,23 @@ describe('Wizard navigation', () => {
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 1, [0], false);
+    checkWizardState(wizard, 1, false, [0], false);
   }));
 
   it('should go to previous step', fakeAsync(() => {
-    checkWizardState(wizard, 0, [], false);
+    checkWizardState(wizard, 0, false, [], false);
 
     wizard.goToStep(1);
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 1, [0], false);
+    checkWizardState(wizard, 1, false, [0], false);
 
     wizard.goToPreviousStep();
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 0, [0], false);
+    checkWizardState(wizard, 0, true, [0], false);
   }));
 
   it('should stay at the current step', fakeAsync(() => {
@@ -125,19 +125,19 @@ describe('Wizard navigation', () => {
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 0, [], false);
+    checkWizardState(wizard, 0, false, [], false);
 
     wizard.goToStep(-1);
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 0, [], false);
+    checkWizardState(wizard, 0, false, [], false);
 
     wizard.goToStep(0);
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 0, [0], false);
+    checkWizardState(wizard, 0, true, [0], false);
   }));
 
   it('should reset the wizard correctly', fakeAsync(() => {
@@ -149,26 +149,26 @@ describe('Wizard navigation', () => {
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 2, [0, 1], false);
+    checkWizardState(wizard, 2, false, [0, 1], false);
 
     wizard.reset();
 
-    checkWizardState(wizard, 0, [], false);
+    checkWizardState(wizard, 0, false, [], false);
 
     wizard.defaultStepIndex = -1;
     expect(() => wizard.reset())
       .toThrow(new Error(`The wizard doesn't contain a step with index -1`));
 
-    checkWizardState(wizard, 0, [], false);
+    checkWizardState(wizard, 0, false, [], false);
 
     wizard.defaultStepIndex = 1;
     wizard.reset();
 
-    checkWizardState(wizard, 1, [], false);
+    checkWizardState(wizard, 1, false, [], false);
 
     wizard.defaultStepIndex = 2;
     wizard.reset();
 
-    checkWizardState(wizard, 2, [], false);
+    checkWizardState(wizard, 2, false, [], false);
   }));
 });

--- a/src/lib/util/step-id.interface.spec.ts
+++ b/src/lib/util/step-id.interface.spec.ts
@@ -88,28 +88,28 @@ describe('StepId', () => {
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 2, [0], false);
+    checkWizardState(wizard, 2, false, [0], false);
 
     // click button
     firstStepGoToButtonEl.click();
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 0, [0], false);
+    checkWizardState(wizard, 0, true, [0], false);
   }));
 
   it('should move to a later step correctly', fakeAsync(() => {
     const firstStepGoToButtonEl = wizardTestFixture.debugElement.query(
       By.css('aw-wizard-step[stepTitle="Steptitle 1"] > button')).nativeElement;
 
-    checkWizardState(wizard, 0, [], false);
+    checkWizardState(wizard, 0, false, [], false);
 
     // click button
     firstStepGoToButtonEl.click();
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 2, [0], false);
+    checkWizardState(wizard, 2, false, [0], false);
   }));
 
   it('should stay at current step correctly', fakeAsync(() => {
@@ -120,14 +120,14 @@ describe('StepId', () => {
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 1, [0], false);
+    checkWizardState(wizard, 1, false, [0], false);
 
     // click button
     firstStepGoToButtonEl.click();
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 1, [0, 1], false);
+    checkWizardState(wizard, 1, true, [0, 1], false);
   }));
 
   it('should return correct destination step for correct targetStep values', fakeAsync(() => {

--- a/src/lib/util/step-id.interface.spec.ts
+++ b/src/lib/util/step-id.interface.spec.ts
@@ -5,6 +5,7 @@ import {ArchwizardModule} from '../archwizard.module';
 import {GoToStepDirective} from '../directives/go-to-step.directive';
 import {NavigationMode} from '../navigation/navigation-mode.interface';
 import {WizardComponent} from '../components/wizard.component';
+import { checkWizardState } from './test-utils';
 
 @Component({
   selector: 'aw-test-wizard',
@@ -83,74 +84,50 @@ describe('StepId', () => {
     const firstStepGoToButtonEl = wizardTestFixture.debugElement.query(
       By.css('aw-wizard-step[stepTitle="Steptitle 3"] > button')).nativeElement;
 
-    const wizardSteps = wizard.wizardSteps;
-
     wizard.goToStep(2);
     tick();
     wizardTestFixture.detectChanges();
 
-    expect(wizard.currentStepIndex).toBe(2);
-    expect(wizardSteps[0].selected).toBe(false);
-    expect(wizardSteps[1].selected).toBe(false);
-    expect(wizardSteps[2].selected).toBe(true);
+    checkWizardState(wizard, 2, [0], false);
 
     // click button
     firstStepGoToButtonEl.click();
     tick();
     wizardTestFixture.detectChanges();
 
-    expect(wizard.currentStepIndex).toBe(0);
-    expect(wizardSteps[0].selected).toBe(true);
-    expect(wizardSteps[1].selected).toBe(false);
-    expect(wizardSteps[2].selected).toBe(false);
+    checkWizardState(wizard, 0, [0], false);
   }));
 
   it('should move to a later step correctly', fakeAsync(() => {
     const firstStepGoToButtonEl = wizardTestFixture.debugElement.query(
       By.css('aw-wizard-step[stepTitle="Steptitle 1"] > button')).nativeElement;
 
-    const wizardSteps = wizard.wizardSteps;
-
-    expect(wizard.currentStepIndex).toBe(0);
-    expect(wizardSteps[0].selected).toBe(true);
-    expect(wizardSteps[1].selected).toBe(false);
-    expect(wizardSteps[2].selected).toBe(false);
+    checkWizardState(wizard, 0, [], false);
 
     // click button
     firstStepGoToButtonEl.click();
     tick();
     wizardTestFixture.detectChanges();
 
-    expect(wizard.currentStepIndex).toBe(2);
-    expect(wizardSteps[0].selected).toBe(false);
-    expect(wizardSteps[1].selected).toBe(false);
-    expect(wizardSteps[2].selected).toBe(true);
+    checkWizardState(wizard, 2, [0], false);
   }));
 
   it('should stay at current step correctly', fakeAsync(() => {
     const firstStepGoToButtonEl = wizardTestFixture.debugElement.query(
       By.css('aw-wizard-step[stepTitle="Steptitle 2"] > button')).nativeElement;
 
-    const wizardSteps = wizard.wizardSteps;
-
     wizard.goToStep(1);
     tick();
     wizardTestFixture.detectChanges();
 
-    expect(wizard.currentStepIndex).toBe(1);
-    expect(wizardSteps[0].selected).toBe(false);
-    expect(wizardSteps[1].selected).toBe(true);
-    expect(wizardSteps[2].selected).toBe(false);
+    checkWizardState(wizard, 1, [0], false);
 
     // click button
     firstStepGoToButtonEl.click();
     tick();
     wizardTestFixture.detectChanges();
 
-    expect(wizard.currentStepIndex).toBe(1);
-    expect(wizardSteps[0].selected).toBe(false);
-    expect(wizardSteps[1].selected).toBe(true);
-    expect(wizardSteps[2].selected).toBe(false);
+    checkWizardState(wizard, 1, [0, 1], false);
   }));
 
   it('should return correct destination step for correct targetStep values', fakeAsync(() => {

--- a/src/lib/util/step-index.interface.spec.ts
+++ b/src/lib/util/step-index.interface.spec.ts
@@ -88,28 +88,28 @@ describe('StepIndex', () => {
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 2, [0], false);
+    checkWizardState(wizard, 2, false, [0], false);
 
     // click button
     firstStepGoToButtonEl.click();
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 0, [0], false);
+    checkWizardState(wizard, 0, true, [0], false);
   }));
 
   it('should move to a later step correctly', fakeAsync(() => {
     const firstStepGoToButtonEl = wizardTestFixture.debugElement.query(
       By.css('aw-wizard-step[stepTitle="Steptitle 1"] > button')).nativeElement;
 
-    checkWizardState(wizard, 0, [], false);
+    checkWizardState(wizard, 0, false, [], false);
 
     // click button
     firstStepGoToButtonEl.click();
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 2, [0], false);
+    checkWizardState(wizard, 2, false, [0], false);
   }));
 
   it('should stay at current step correctly', fakeAsync(() => {
@@ -120,14 +120,14 @@ describe('StepIndex', () => {
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 1, [0], false);
+    checkWizardState(wizard, 1, false, [0], false);
 
     // click button
     firstStepGoToButtonEl.click();
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 1, [0, 1], false);
+    checkWizardState(wizard, 1, true, [0, 1], false);
   }));
 
   it('should return correct destination step for correct targetStep values', fakeAsync(() => {

--- a/src/lib/util/step-index.interface.spec.ts
+++ b/src/lib/util/step-index.interface.spec.ts
@@ -5,6 +5,7 @@ import {ArchwizardModule} from '../archwizard.module';
 import {GoToStepDirective} from '../directives/go-to-step.directive';
 import {NavigationMode} from '../navigation/navigation-mode.interface';
 import {WizardComponent} from '../components/wizard.component';
+import { checkWizardState } from './test-utils';
 
 @Component({
   selector: 'aw-test-wizard',
@@ -83,74 +84,50 @@ describe('StepIndex', () => {
     const firstStepGoToButtonEl = wizardTestFixture.debugElement.query(
       By.css('aw-wizard-step[stepTitle="Steptitle 3"] > button')).nativeElement;
 
-    const wizardSteps = wizard.wizardSteps;
-
     wizard.goToStep(2);
     tick();
     wizardTestFixture.detectChanges();
 
-    expect(wizard.currentStepIndex).toBe(2);
-    expect(wizardSteps[0].selected).toBe(false);
-    expect(wizardSteps[1].selected).toBe(false);
-    expect(wizardSteps[2].selected).toBe(true);
+    checkWizardState(wizard, 2, [0], false);
 
     // click button
     firstStepGoToButtonEl.click();
     tick();
     wizardTestFixture.detectChanges();
 
-    expect(wizard.currentStepIndex).toBe(0);
-    expect(wizardSteps[0].selected).toBe(true);
-    expect(wizardSteps[1].selected).toBe(false);
-    expect(wizardSteps[2].selected).toBe(false);
+    checkWizardState(wizard, 0, [0], false);
   }));
 
   it('should move to a later step correctly', fakeAsync(() => {
     const firstStepGoToButtonEl = wizardTestFixture.debugElement.query(
       By.css('aw-wizard-step[stepTitle="Steptitle 1"] > button')).nativeElement;
 
-    const wizardSteps = wizard.wizardSteps;
-
-    expect(wizard.currentStepIndex).toBe(0);
-    expect(wizardSteps[0].selected).toBe(true);
-    expect(wizardSteps[1].selected).toBe(false);
-    expect(wizardSteps[2].selected).toBe(false);
+    checkWizardState(wizard, 0, [], false);
 
     // click button
     firstStepGoToButtonEl.click();
     tick();
     wizardTestFixture.detectChanges();
 
-    expect(wizard.currentStepIndex).toBe(2);
-    expect(wizardSteps[0].selected).toBe(false);
-    expect(wizardSteps[1].selected).toBe(false);
-    expect(wizardSteps[2].selected).toBe(true);
+    checkWizardState(wizard, 2, [0], false);
   }));
 
   it('should stay at current step correctly', fakeAsync(() => {
     const firstStepGoToButtonEl = wizardTestFixture.debugElement.query(
       By.css('aw-wizard-step[stepTitle="Steptitle 2"] > button')).nativeElement;
 
-    const wizardSteps = wizard.wizardSteps;
-
     wizard.goToStep(1);
     tick();
     wizardTestFixture.detectChanges();
 
-    expect(wizard.currentStepIndex).toBe(1);
-    expect(wizardSteps[0].selected).toBe(false);
-    expect(wizardSteps[1].selected).toBe(true);
-    expect(wizardSteps[2].selected).toBe(false);
+    checkWizardState(wizard, 1, [0], false);
 
     // click button
     firstStepGoToButtonEl.click();
     tick();
     wizardTestFixture.detectChanges();
 
-    expect(wizard.currentStepIndex).toBe(1);
-    expect(wizardSteps[0].selected).toBe(false);
-    expect(wizardSteps[1].selected).toBe(true);
-    expect(wizardSteps[2].selected).toBe(false);
+    checkWizardState(wizard, 1, [0, 1], false);
   }));
 
   it('should return correct destination step for correct targetStep values', fakeAsync(() => {

--- a/src/lib/util/step-offset.interface.spec.ts
+++ b/src/lib/util/step-offset.interface.spec.ts
@@ -5,6 +5,7 @@ import {ArchwizardModule} from '../archwizard.module';
 import {GoToStepDirective} from '../directives/go-to-step.directive';
 import {NavigationMode} from '../navigation/navigation-mode.interface';
 import {WizardComponent} from '../components/wizard.component';
+import { checkWizardState } from './test-utils';
 
 @Component({
   selector: 'aw-test-wizard',
@@ -83,74 +84,50 @@ describe('StepOffset', () => {
     const firstStepGoToButtonEl = wizardTestFixture.debugElement.query(
       By.css('aw-wizard-step[stepTitle="Steptitle 3"] > button')).nativeElement;
 
-    const wizardSteps = wizard.wizardSteps;
-
     wizard.goToStep(2);
     tick();
     wizardTestFixture.detectChanges();
 
-    expect(wizard.currentStepIndex).toBe(2);
-    expect(wizardSteps[0].selected).toBe(false);
-    expect(wizardSteps[1].selected).toBe(false);
-    expect(wizardSteps[2].selected).toBe(true);
+    checkWizardState(wizard, 2, [0], false);
 
     // click button
     firstStepGoToButtonEl.click();
     tick();
     wizardTestFixture.detectChanges();
 
-    expect(wizard.currentStepIndex).toBe(0);
-    expect(wizardSteps[0].selected).toBe(true);
-    expect(wizardSteps[1].selected).toBe(false);
-    expect(wizardSteps[2].selected).toBe(false);
+    checkWizardState(wizard, 0, [0], false);
   }));
 
   it('should move to a later step correctly', fakeAsync(() => {
     const firstStepGoToButtonEl = wizardTestFixture.debugElement.query(
       By.css('aw-wizard-step[stepTitle="Steptitle 1"] > button')).nativeElement;
 
-    const wizardSteps = wizard.wizardSteps;
-
-    expect(wizard.currentStepIndex).toBe(0);
-    expect(wizardSteps[0].selected).toBe(true);
-    expect(wizardSteps[1].selected).toBe(false);
-    expect(wizardSteps[2].selected).toBe(false);
+    checkWizardState(wizard, 0, [], false);
 
     // click button
     firstStepGoToButtonEl.click();
     tick();
     wizardTestFixture.detectChanges();
 
-    expect(wizard.currentStepIndex).toBe(2);
-    expect(wizardSteps[0].selected).toBe(false);
-    expect(wizardSteps[1].selected).toBe(false);
-    expect(wizardSteps[2].selected).toBe(true);
+    checkWizardState(wizard, 2, [0], false);
   }));
 
   it('should stay at current step correctly', fakeAsync(() => {
     const firstStepGoToButtonEl = wizardTestFixture.debugElement.query(
       By.css('aw-wizard-step[stepTitle="Steptitle 2"] > button')).nativeElement;
 
-    const wizardSteps = wizard.wizardSteps;
-
     wizard.goToStep(1);
     tick();
     wizardTestFixture.detectChanges();
 
-    expect(wizard.currentStepIndex).toBe(1);
-    expect(wizardSteps[0].selected).toBe(false);
-    expect(wizardSteps[1].selected).toBe(true);
-    expect(wizardSteps[2].selected).toBe(false);
+    checkWizardState(wizard, 1, [0], false);
 
     // click button
     firstStepGoToButtonEl.click();
     tick();
     wizardTestFixture.detectChanges();
 
-    expect(wizard.currentStepIndex).toBe(1);
-    expect(wizardSteps[0].selected).toBe(false);
-    expect(wizardSteps[1].selected).toBe(true);
-    expect(wizardSteps[2].selected).toBe(false);
+    checkWizardState(wizard, 1, [0, 1], false);
   }));
 
   it('should return correct destination step for correct targetStep values', fakeAsync(() => {

--- a/src/lib/util/step-offset.interface.spec.ts
+++ b/src/lib/util/step-offset.interface.spec.ts
@@ -88,28 +88,28 @@ describe('StepOffset', () => {
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 2, [0], false);
+    checkWizardState(wizard, 2, false, [0], false);
 
     // click button
     firstStepGoToButtonEl.click();
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 0, [0], false);
+    checkWizardState(wizard, 0, true, [0], false);
   }));
 
   it('should move to a later step correctly', fakeAsync(() => {
     const firstStepGoToButtonEl = wizardTestFixture.debugElement.query(
       By.css('aw-wizard-step[stepTitle="Steptitle 1"] > button')).nativeElement;
 
-    checkWizardState(wizard, 0, [], false);
+    checkWizardState(wizard, 0, false, [], false);
 
     // click button
     firstStepGoToButtonEl.click();
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 2, [0], false);
+    checkWizardState(wizard, 2, false, [0], false);
   }));
 
   it('should stay at current step correctly', fakeAsync(() => {
@@ -120,14 +120,14 @@ describe('StepOffset', () => {
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 1, [0], false);
+    checkWizardState(wizard, 1, false, [0], false);
 
     // click button
     firstStepGoToButtonEl.click();
     tick();
     wizardTestFixture.detectChanges();
 
-    checkWizardState(wizard, 1, [0, 1], false);
+    checkWizardState(wizard, 1, true, [0, 1], false);
   }));
 
   it('should return correct destination step for correct targetStep values', fakeAsync(() => {

--- a/src/lib/util/test-utils.ts
+++ b/src/lib/util/test-utils.ts
@@ -26,10 +26,16 @@ export function checkWizardState(
     expect(step.completed).toBe(completedStepIndexes.includes(index),
       `expected step ${index} ${completedStepIndexes.includes(index) ? 'to be completed' : 'not to be completed'}`);
 
-    // Check step "editing" state
+    // Check step "editing" state.  It is only applicable to the selected step.
     const expectation = index === selectedStepIndex && selectedStepEditing ? 'to be in editing state' : 'not to be in editing state';
     expect(step.editing).toBe(index === selectedStepIndex && selectedStepEditing, `expected step ${index} ${expectation}`);
   });
+
+  // A step in "editing" state should also be completed
+  if (selectedStepEditing) {
+    expect(completedStepIndexes).toContain(selectedStepIndex,
+      `expected step ${selectedStepIndex} to be completed, as follows from its assumed editing state`);
+  }
 
   expect(wizard.completed).toBe(wizardCompleted,
     `expected wizard ${wizardCompleted ? 'to be completed' : 'not to be completed'}`);

--- a/src/lib/util/test-utils.ts
+++ b/src/lib/util/test-utils.ts
@@ -5,12 +5,14 @@ import { WizardComponent } from '../components/wizard.component';
  *
  * @param wizard Wizard component under test
  * @param selectedStepIndex Expected selected step index
+ * @param selectedStepEditing Whether the selected step is expected to be in "editing" state
  * @param completedStepIndexes Array of step indexes expected to be completed
  * @param wizardCompleted Whether the whole wizard is expected to be completed
  */
 export function checkWizardState(
   wizard: WizardComponent,
   selectedStepIndex: number,
+  selectedStepEditing: boolean,
   completedStepIndexes: number[],
   wizardCompleted: boolean,
 ): void {
@@ -20,9 +22,13 @@ export function checkWizardState(
     // Only the selected step should be selected
     expect(step.selected).toBe(index === selectedStepIndex, `expected only step ${index} to be selected`);
 
-    // All steps before the selected step need to be completed
+    // Check completed step indexes
     expect(step.completed).toBe(completedStepIndexes.includes(index),
       `expected step ${index} ${completedStepIndexes.includes(index) ? 'to be completed' : 'not to be completed'}`);
+
+    // Check step "editing" state
+    const expectation = index === selectedStepIndex && selectedStepEditing ? 'to be in editing state' : 'not to be in editing state';
+    expect(step.editing).toBe(index === selectedStepIndex && selectedStepEditing, `expected step ${index} ${expectation}`);
   });
 
   expect(wizard.completed).toBe(wizardCompleted,

--- a/src/lib/util/wizard-step.interface.ts
+++ b/src/lib/util/wizard-step.interface.ts
@@ -56,6 +56,13 @@ export abstract class WizardStep {
   public selected = false;
 
   /**
+   * A boolean describing if the wizard step is being edited after being competed
+   *
+   * This flag can only be true when `selected` is true.
+   */
+  public editing = false;
+
+  /**
    * A boolean describing, if the wizard step should be selected by default, i.e. after the wizard has been initialized as the initial step
    */
   public defaultSelected = false;


### PR DESCRIPTION
Solves #213 by following the suggestion from https://github.com/madoar/angular-archwizard/issues/213#issuecomment-501008323

<a href="https://gitpod.io/#https://github.com/madoar/angular-archwizard/pull/221"><img src="https://gitpod.io/api/apps/github/pbs/github.com/earshinov/angular-archwizard.git/2f354a584d4c130eb29928dcbc65ab48e51b01f7.svg" /></a>

