### PR TITLE
Advanced styles customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,7 +630,7 @@ invalid state, which may lead to strange and unexpected behavior.
 
 ## Styles Customization
 
-If you are using SCSS, you can customize wizard's global styles and color theme using SCSS variables:
+If you are using SCSS, you can customize the wizard's global styles and color theme using SCSS variables:
 
 1. Import `node_modules/angular-archwizard/archwizard.scss` into your `styles.scss` file as described in the [Installation](#installation) section.
 2. Re-define any of the variables you can find at the top of `node_modules/angular-archwizard/variables.scss`.

--- a/README.md
+++ b/README.md
@@ -630,20 +630,42 @@ invalid state, which may lead to strange and unexpected behavior.
 
 ## Styles Customization
 
-If you are using SCSS, you can easily customize wizard's global styles and color theme using SCSS variables:
+If you are using SCSS, you can customize wizard's global styles and color theme using SCSS variables:
 
 1. Import `node_modules/angular-archwizard/archwizard.scss` into your `styles.scss` file as described in the [Installation](#installation) section.
-2. Re-define any of the variables you can find at the top of `node_modules/angular-archwizard/archwizard.scss`.
+2. Re-define any of the variables you can find at the top of `node_modules/angular-archwizard/variables.scss`.
 
-Here is a quick example:
+In the following example, we configure a simple color theme which only defines styles for two step states: 'default' and 'current'.
 
 ```scss
 // styles.scss
 
-$wz-color-default: #569700;
+$aw-colors: (
+  '_': (
+    'default': (
+      'border-color-default': #76b900,
+      'background-color-default': null,
+      'symbol-color-default': #68aa20,
+      'border-color-hover': #569700,
+      'background-color-hover': null,
+      'symbol-color-hover': #569700,
+    ),
+    'current': (
+      'border-color-default': #bbdc80,
+      'background-color-default': #bbdc80,
+      'symbol-color-default': #808080,
+      'border-color-hover': #76b900,
+      'background-color-hover': #76b900,
+      'symbol-color-hover': #808080,
+    )
+  )
+);
 
 @import '../node_modules/angular-archwizard/archwizard.scss';
 ```
+
+Please don't hesitate to look inside `node_modules/angular-archwizard/variables.scss` for documentation
+on the `$aw-colors` variable and other variables you can tweak to tune the wizard to your needs.
 
 ## Example
 You can find an basic example project using `angular-archwizard` [here](https://madoar.github.io/angular-archwizard-demo).

--- a/src/css/archwizard.scss
+++ b/src/css/archwizard.scss
@@ -19,7 +19,7 @@ $wz-indicator-styles: 'small', 'large-filled', 'large-empty', 'large-filled-symb
 //
 // Notes:
 // - The order of wizard step states in this mapping does not affect the order of resulting CSS rules, which is fixed
-//   internally by angular-archwizard.
+//   internally by angular-archwizard (see `wz-define-style` mixin).
 // - Depending on the active indicator style, some colors may not be used.  For example, 'background-color-default' and
 //   'background-color-hover' do not make sense in 'large-empty-symbols' indicator style.
 // - You can set a color to `null` to exclude the corresponding property from CSS output.

--- a/src/css/archwizard.scss
+++ b/src/css/archwizard.scss
@@ -5,6 +5,9 @@ $wz-color-done: #339933 !default;
 $wz-color-optional: #38ef38 !default;
 $wz-color-editing: #FF0000 !default;
 
+// line color
+$wz-line-color: #E6E6E6 !default;
+
 // label colors
 $wz-label-color-default: #808080 !default;
 $wz-label-color-hover: darken($wz-label-color-default, 20%) !default;

--- a/src/css/archwizard.scss
+++ b/src/css/archwizard.scss
@@ -1,10 +1,10 @@
 // Wizard layouts to be generated (all by default).
 // Override this variable to exclude layouts you don't need.
-$wz-layouts: 'horizontal' 'vertical' !default;
+$aw-layouts: 'horizontal' 'vertical' !default;
 
 // Wizard indicator styles to be generated (all by default).
 // Override this variable to exclude indicator styles you don't use.
-$wz-indicator-styles: 'small', 'large-filled', 'large-empty', 'large-filled-symbols', 'large-empty-symbols' !default;
+$aw-indicator-styles: 'small', 'large-filled', 'large-empty', 'large-filled-symbols', 'large-empty-symbols' !default;
 
 // Color definitions - a mapping from indicator style and wizard step state to colors.
 //
@@ -18,7 +18,7 @@ $wz-indicator-styles: 'small', 'large-filled', 'large-empty', 'large-filled-symb
 //
 // Notes:
 // - The order of wizard step states in this mapping does not affect the order of resulting CSS rules, which is fixed
-//   internally by angular-archwizard (see `wz-define-style` mixin).
+//   internally by angular-archwizard (see `aw-define-style` mixin).
 // - Depending on the active indicator style, some colors may not be used.  For example, 'background-color-default' and
 //   'background-color-hover' do not make sense in 'large-empty-symbols' indicator style.
 //
@@ -27,7 +27,7 @@ $wz-indicator-styles: 'small', 'large-filled', 'large-empty', 'large-filled-symb
 //
 // You can use `null` instead of a color value to exclude the corresponding property from CSS output.  For example,
 //
-//   $wz-colors: (
+//   $aw-colors: (
 //     '_': (
 //       'editing': (
 //         'border-color-default': null,
@@ -42,14 +42,14 @@ $wz-indicator-styles: 'small', 'large-filled', 'large-empty', 'large-filled-symb
 // --------------
 //
 // You can set default colors by using '_' in place of an indicator style or a wizard step state.
-// The `wz-get-color` function looks up the requested color in the following order, picking the first defined entry:
+// The `aw-get-color` function looks up the requested color in the following order, picking the first defined entry:
 //
-// - $wz-colors[$indicator-style][$step-state][$color]
-// - $wz-colors[$indicator-style]['_'][$color]
-// - $wz-colors['_'][$step-state][$color]
-// - $wz-colors['_']['_'][$color]
+// - $aw-colors[$indicator-style][$step-state][$color]
+// - $aw-colors[$indicator-style]['_'][$color]
+// - $aw-colors['_'][$step-state][$color]
+// - $aw-colors['_']['_'][$color]
 //
-$wz-colors: (
+$aw-colors: (
   '_': (
     'default': (
       'border-color-default': #E6E6E6,
@@ -101,11 +101,11 @@ $wz-colors: (
 ) !default;
 
 // line color
-$wz-line-color: #E6E6E6 !default;
+$aw-line-color: #E6E6E6 !default;
 
 // label colors
-$wz-label-color-default: #808080 !default;
-$wz-label-color-hover: darken($wz-label-color-default, 20%) !default;
+$aw-label-color-default: #808080 !default;
+$aw-label-color-hover: darken($aw-label-color-default, 20%) !default;
 
 // dot definitions
 //
@@ -120,26 +120,26 @@ $wz-label-color-hover: darken($wz-label-color-default, 20%) !default;
 //
 // It is recommended to always have dot-width equal to dot-height.
 //
-$wz-dot-border-width: 2px !default;
+$aw-dot-border-width: 2px !default;
 
 // small definitions
-$wz-small-dot-width: 14px !default;
-$wz-small-dot-height: 14px !default;
+$aw-small-dot-width: 14px !default;
+$aw-small-dot-height: 14px !default;
 
 // big definitions
-$wz-big-dot-width: 50px !default;
-$wz-big-dot-height: 50px !default;
+$aw-big-dot-width: 50px !default;
+$aw-big-dot-height: 50px !default;
 
 // padding between text and baseline, for horizonal navigation bar
-$wz-text-padding-bottom: 10px !default;
+$aw-text-padding-bottom: 10px !default;
 
 // padding between text and baseline, for vertical navigation bar
-$wz-text-margin-left: 15px !default;
+$aw-text-margin-left: 15px !default;
 
 // distance between steps, for vertical navigation bar
-$wz-distance-between-steps: 10px !default;
+$aw-distance-between-steps: 10px !default;
 
-$wz-text-height: 14px !default;
+$aw-text-height: 14px !default;
 
 
 aw-wizard {

--- a/src/css/archwizard.scss
+++ b/src/css/archwizard.scss
@@ -22,7 +22,22 @@ $wz-indicator-styles: 'small', 'large-filled', 'large-empty', 'large-filled-symb
 //   internally by angular-archwizard (see `wz-define-style` mixin).
 // - Depending on the active indicator style, some colors may not be used.  For example, 'background-color-default' and
 //   'background-color-hover' do not make sense in 'large-empty-symbols' indicator style.
-// - You can set a color to `null` to exclude the corresponding property from CSS output.
+//
+// 'Null' colors
+// -------------
+//
+// You can use `null` instead of a color value to exclude the corresponding property from CSS output.  For example,
+//
+//   $wz-colors: (
+//     '_': (
+//       'editing': (
+//         'border-color-default': null,
+//         'border-color-hover': null
+//       )
+//     )
+//   )
+//
+//   will turn off red border for wizard steps in 'editing' state.
 //
 // Default colors
 // --------------

--- a/src/css/archwizard.scss
+++ b/src/css/archwizard.scss
@@ -107,11 +107,11 @@ $aw-line-color: #E6E6E6 !default;
 $aw-label-color-default: #808080 !default;
 $aw-label-color-hover: darken($aw-label-color-default, 20%) !default;
 
-// dot definitions
+// Circle definitions
 //
-// Here and below, "dots" are wizard step indicators represented as circles in the navigation bar.
-// Depending on the step indicator style selected for the wizard, dots can either be small (indicator style 'small')
-// or large (indicator styles 'large-filled', 'large-empty', 'large-filled-symbols' etc.).
+// Circles are the visual representation of wizard steps in the navigation bar.  Depending on
+// the step indicator style selected for the wizard, circles are either small (indicator style 'small')
+// or big (indicator styles 'large-filled', 'large-empty', 'large-filled-symbols' etc.).
 //
 // A short summary of available configuration options:
 // - dot-border-width defines circle border width
@@ -120,15 +120,15 @@ $aw-label-color-hover: darken($aw-label-color-default, 20%) !default;
 //
 // It is recommended to always have dot-width equal to dot-height.
 //
-$aw-dot-border-width: 2px !default;
+$aw-circle-border-width: 2px !default;
 
 // small definitions
-$aw-small-dot-width: 14px !default;
-$aw-small-dot-height: 14px !default;
+$aw-small-circle-width: 14px !default;
+$aw-small-circle-height: 14px !default;
 
 // big definitions
-$aw-big-dot-width: 50px !default;
-$aw-big-dot-height: 50px !default;
+$aw-big-circle-width: 50px !default;
+$aw-big-circle-height: 50px !default;
 
 // padding between text and baseline, for horizonal navigation bar
 $aw-text-padding-bottom: 10px !default;

--- a/src/css/archwizard.scss
+++ b/src/css/archwizard.scss
@@ -15,7 +15,8 @@ $wz-indicator-styles: 'small', 'large-filled', 'large-empty', 'large-filled-symb
 // Wizard step states are: 'default', 'current', 'done', 'optional', 'editing'.
 //
 // Colors are: 'border-color-default', 'background-color-default', 'symbol-color-default', 'border-color-hover',
-// 'background-color-hover', 'symbol-color-hover'.
+// 'background-color-hover', 'symbol-color-hover'.  The 'hover' values are applied when the user hovers the mouse
+// pointer over a navigable wizard step indicator.  Otherwise the 'default' values are used.
 //
 // Notes:
 // - The order of wizard step states in this mapping does not affect the order of resulting CSS rules, which is fixed

--- a/src/css/archwizard.scss
+++ b/src/css/archwizard.scss
@@ -110,6 +110,18 @@ $wz-label-color-default: #808080 !default;
 $wz-label-color-hover: darken($wz-label-color-default, 20%) !default;
 
 // dot definitions
+//
+// Here and below, "dots" are wizard step indicators represented as circles in the navigation bar.
+// Depending on step indicator style selected for the wizard, dots can either be small (indicator style 'small')
+// or large (indicator styles 'large-filled', 'large-empty', 'large-filled-symbols' etc.).
+//
+// A short summary of available configuration options:
+// - dot-border-width defines circle border width
+// - dot-width defines the horizontal dimension of circles
+// - dot-height defines the vertical dimension of circles
+//
+// It is recommended to always have dot-width equal to dot-height.
+//
 $wz-dot-border-width: 2px !default;
 
 // small definitions

--- a/src/css/archwizard.scss
+++ b/src/css/archwizard.scss
@@ -110,7 +110,7 @@ $wz-label-color-hover: darken($wz-label-color-default, 20%) !default;
 // dot definitions
 //
 // Here and below, "dots" are wizard step indicators represented as circles in the navigation bar.
-// Depending on step indicator style selected for the wizard, dots can either be small (indicator style 'small')
+// Depending on the step indicator style selected for the wizard, dots can either be small (indicator style 'small')
 // or large (indicator styles 'large-filled', 'large-empty', 'large-filled-symbols' etc.).
 //
 // A short summary of available configuration options:

--- a/src/css/archwizard.scss
+++ b/src/css/archwizard.scss
@@ -5,6 +5,10 @@ $wz-color-done: #339933 !default;
 $wz-color-optional: #38ef38 !default;
 $wz-color-editing: #FF0000 !default;
 
+// label colors
+$wz-label-color-default: #808080 !default;
+$wz-label-color-hover: darken($wz-label-color-default, 20%) !default;
+
 // dot definitions
 $wz-dot-border-width: 2px !default;
 

--- a/src/css/archwizard.scss
+++ b/src/css/archwizard.scss
@@ -6,9 +6,7 @@ $wz-layouts: 'horizontal' 'vertical' !default;
 // Override this variable to exclude indicator styles you don't use.
 $wz-indicator-styles: 'small', 'large-filled', 'large-empty', 'large-filled-symbols', 'large-empty-symbols' !default;
 
-// Color definitions
-//
-// This is a mapping from indicator style and wizard step state to colors.
+// Color definitions - a mapping from indicator style and wizard step state to colors.
 //
 // Predefined indicator styles are: 'small', 'large-filled', 'large-empty', 'large-filled-symbols', 'large-empty-symbols'.
 //

--- a/src/css/archwizard.scss
+++ b/src/css/archwizard.scss
@@ -1,9 +1,90 @@
-// color definitions
-$wz-color-default: #E6E6E6 !default;
-$wz-color-current: #808080 !default;
-$wz-color-done: #339933 !default;
-$wz-color-optional: #38ef38 !default;
-$wz-color-editing: #FF0000 !default;
+// Wizard layouts to be generated (all by default).
+// Override this variable to exclude layouts you don't need.
+$wz-layouts: 'horizontal' 'vertical' !default;
+
+// Wizard indicator styles to be generated (all by default).
+// Override this variable to exclude indicator styles you don't use.
+$wz-indicator-styles: 'small', 'large-filled', 'large-empty', 'large-filled-symbols', 'large-empty-symbols' !default;
+
+// Color definitions
+//
+// This is a mapping from indicator style and wizard step state to colors.
+//
+// Predefined indicator styles are: 'small', 'large-filled', 'large-empty', 'large-filled-symbols', 'large-empty-symbols'.
+//
+// Wizard step states are: 'default', 'current', 'done', 'optional', 'editing'.
+//
+// Colors are: 'border-color-default', 'background-color-default', 'symbol-color-default', 'border-color-hover',
+// 'background-color-hover', 'symbol-color-hover'.
+//
+// Notes:
+// - The order of wizard step states in this mapping does not affect the order of resulting CSS rules, which is fixed
+//   internally by angular-archwizard.
+// - Depending on the active indicator style, some colors may not be used.  For example, 'background-color-default' and
+//   'background-color-hover' do not make sense in 'large-empty-symbols' indicator style.
+// - You can set a color to `null` to exclude the corresponding property from CSS output.
+//
+// Default colors
+// --------------
+//
+// You can set default colors by using '_' in place of an indicator style or a wizard step state.
+// The `wz-get-color` function looks up the requested color in the following order, picking the first defined entry:
+//
+// - $wz-colors[$indicator-style][$step-state][$color]
+// - $wz-colors[$indicator-style]['_'][$color]
+// - $wz-colors['_'][$step-state][$color]
+// - $wz-colors['_']['_'][$color]
+//
+$wz-colors: (
+  '_': (
+    'default': (
+      'border-color-default': #E6E6E6,
+      'background-color-default': #E6E6E6,
+      'symbol-color-default': #E6E6E6,
+      'border-color-hover': darken(#E6E6E6, 10%),
+      'background-color-hover': darken(#E6E6E6, 5%),
+      'symbol-color-hover': darken(#E6E6E6, 10%),
+    ),
+    'current': (
+      'border-color-default': #808080,
+      'background-color-default': #808080,
+      'symbol-color-default': #808080,
+      'border-color-hover': darken(#808080, 10%),
+      'background-color-hover': darken(#808080, 5%),
+      'symbol-color-hover': darken(#808080, 10%),
+    ),
+    'done': (
+      'border-color-default': #339933,
+      'background-color-default': #339933,
+      'symbol-color-default': #339933,
+      'border-color-hover': darken(#339933, 10%),
+      'background-color-hover': darken(#339933, 5%),
+      'symbol-color-hover': darken(#339933, 10%),
+    ),
+    'optional': (
+      'border-color-default': #38ef38,
+      'background-color-default': #38ef38,
+      'symbol-color-default': #38ef38,
+      'border-color-hover': darken(#38ef38, 10%),
+      'background-color-hover': darken(#38ef38, 5%),
+      'symbol-color-hover': darken(#38ef38, 10%),
+    ),
+    'editing': (
+      'border-color-default': #FF0000,
+      'background-color-default': #FF0000,
+      'symbol-color-default': #FF0000,
+      'border-color-hover': darken(#FF0000, 10%),
+      'background-color-hover': darken(#FF0000, 5%),
+      'symbol-color-hover': darken(#FF0000, 10%),
+    ),
+  ),
+  'large-filled-symbols': (
+    '_': (
+      'symbol-color-default': black,
+      'symbol-color-hover': black,
+    )
+  )
+) !default;
 
 // line color
 $wz-line-color: #E6E6E6 !default;

--- a/src/css/wizard-navigation-bar.scss
+++ b/src/css/wizard-navigation-bar.scss
@@ -13,8 +13,8 @@
 // indicator state: 'default' or 'hover'
 $wz-param-indicator-state: null !global;
 
-// base color for one of possible wizard step states (default, current, done etc.).
-$wz-param-indicator-color: null !global;
+// wizard step state: 'default', 'current', 'done' etc.
+$wz-param-step-state: null !global;
 
 
 @mixin wz-horizontal-line($dot-width, $dot-height, $line-color) {
@@ -47,7 +47,7 @@ $wz-param-indicator-color: null !global;
   left: -$dot-width;
 }
 
-@mixin wz-state-circle($dot-width, $dot-height, $dot-border-width) {
+@mixin wz-circle($dot-width, $dot-height, $dot-border-width) {
   position: absolute;
   width: $dot-width;
   height: $dot-height;
@@ -58,28 +58,8 @@ $wz-param-indicator-color: null !global;
   border-radius: 100%;
 }
 
-@mixin wz-state-circle-with-border($color) {
-  border-width: $wz-param-indicator-border-width;
-  border-style: solid;
-  border-color: if($wz-param-indicator-state == 'hover', darken($color, 10%), $color);
-}
 
-@mixin wz-state-circle-with-border-and-content($color) {
-  @include wz-state-circle-with-border($color);
-  color: if($wz-param-indicator-state == 'hover', darken($color, 10%), $color);
-}
-
-@mixin wz-state-circle-with-background($color) {
-  background-color: if($wz-param-indicator-state == 'hover', darken($color, 5%), $color);
-}
-
-@mixin wz-state-circle-with-background-and-content($color) {
-  @include wz-state-circle-with-background($color);
-  color: black;
-}
-
-
-// Helper mixin to define a step indicator style like 'small', 'large-filled-symbols' etc.
+// Define a step indicator style like 'small', 'large-filled' etc.
 //
 // Arguments:
 //   $layout - 'horizontal' | 'vertical'
@@ -92,7 +72,7 @@ $wz-param-indicator-color: null !global;
 // The content block is invoked several times, each time with different arguments passed through global variables:
 //
 //   - $wz-param-indicator-state - indicator state: 'default' or 'hover'
-//   - $wz-param-indicator-color - base color for one of possible wizard step states (default, current, done etc.)
+//   - $wz-param-step-state - wizard step state: 'default', 'current', 'done' etc.
 //
 // In addition to these variables, the content block can use the following
 // variables passed through the `define-style` mixin:
@@ -140,120 +120,151 @@ $wz-param-indicator-color: null !global;
       }
 
       $wz-param-indicator-state: 'default' !global;
-      $wz-param-indicator-color: $wz-color-default !global;
-      @include wz-state-circle($width, $height, $border-width);
+      $wz-param-step-state: 'default' !global;
+      @include wz-circle($width, $height, $border-width);
       @content;
     }
     &.optional .step-indicator {
       $wz-param-indicator-state: 'default' !global;
-      $wz-param-indicator-color: $wz-color-optional !global;
+      $wz-param-step-state: 'optional' !global;
       @content;
     }
     &.done .step-indicator {
       $wz-param-indicator-state: 'default' !global;
-      $wz-param-indicator-color: $wz-color-done !global;
+      $wz-param-step-state: 'done' !global;
       @content;
     }
     &.current .step-indicator {
       $wz-param-indicator-state: 'default' !global;
-      $wz-param-indicator-color: $wz-color-current !global;
+      $wz-param-step-state: 'current' !global;
       @content;
     }
     &.editing .step-indicator {
       $wz-param-indicator-state: 'default' !global;
-      $wz-param-indicator-color: $wz-color-editing !global;
+      $wz-param-step-state: 'editing' !global;
       @content;
     }
     // 'completed' class takes priority
     // https://github.com/madoar/angular-archwizard/pull/221
     &.completed .step-indicator {
       $wz-param-indicator-state: 'default' !global;
-      $wz-param-indicator-color: $wz-color-done !global;
+      $wz-param-step-state: 'done' !global;
       @content;
     }
 
     &.navigable a:hover .step-indicator {
       $wz-param-indicator-state: 'hover' !global;
-      $wz-param-indicator-color: $wz-color-default !global;
-      @include wz-state-circle($width, $height, $border-width);
+      $wz-param-step-state: 'default' !global;
+      @include wz-circle($width, $height, $border-width);
       @content;
     }
     &.navigable.optional a:hover .step-indicator {
       $wz-param-indicator-state: 'hover' !global;
-      $wz-param-indicator-color: $wz-color-optional !global;
+      $wz-param-step-state: 'optional' !global;
       @content;
     }
     &.navigable.done a:hover .step-indicator {
       $wz-param-indicator-state: 'hover' !global;
-      $wz-param-indicator-color: $wz-color-done !global;
+      $wz-param-step-state: 'done' !global;
       @content;
     }
     &.navigable.current a:hover .step-indicator {
       $wz-param-indicator-state: 'hover' !global;
-      $wz-param-indicator-color: $wz-color-current !global;
+      $wz-param-step-state: 'current' !global;
       @content;
     }
     &.navigable.editing a:hover .step-indicator {
       $wz-param-indicator-state: 'hover' !global;
-      $wz-param-indicator-color: $wz-color-editing !global;
+      $wz-param-step-state: 'editing' !global;
       @content;
     }
     // 'completed' class takes priority
     // https://github.com/madoar/angular-archwizard/pull/221
     &.navigable.completed a:hover .step-indicator {
       $wz-param-indicator-state: 'hover' !global;
-      $wz-param-indicator-color: $wz-color-done !global;
+      $wz-param-step-state: 'done' !global;
       @content;
     }
   }
 }
 
 
-// Helper mixin to define indicator styles like 'small', 'large-filled-symbols' etc. for the given layout
-//
-// Arguments:
-//   $layout - 'horizontal' | 'vertical'
-//
-@mixin wz-define-styles($layout) {
-  &.small ul.steps-indicator {
-    @include wz-define-style($layout, $width: $wz-small-dot-width, $height: $wz-small-dot-height, $border-width: 0) {
-      @include wz-state-circle-with-background($wz-param-indicator-color);
-    }
-  }
+// Define wizard styles specific to the configurated layouts (`$wz-layouts`) and indicator styles (`$wz-indicator-styles`)
+@mixin wz-define-styles() {
+  @each $layout in $wz-layouts {
+    aw-wizard-navigation-bar.#{$layout} {
+      @each $indicator-style in $wz-indicator-styles {
+        &.#{$indicator-style} ul.steps-indicator {
 
-  &.large-filled ul.steps-indicator {
-    @include wz-define-style($layout, $border-width: 0) {
-      @include wz-state-circle-with-background($wz-param-indicator-color);
-    }
-  }
+          @if $indicator-style == 'small' {
+            @include wz-define-style($layout, $width: $wz-small-dot-width, $height: $wz-small-dot-height, $border-width: 0) {
+              background-color: wz-get-color($indicator-style, $wz-param-step-state, $wz-param-indicator-state, 'background-color');
+            }
+          }
 
-  &.large-empty ul.steps-indicator {
-    @include wz-define-style($layout) {
-      @include wz-state-circle-with-border($wz-param-indicator-color);
-    }
-  }
+          @else if $indicator-style == 'large-filled' {
+            @include wz-define-style($layout, $border-width: 0) {
+              background-color: wz-get-color($indicator-style, $wz-param-step-state, $wz-param-indicator-state, 'background-color');
+            }
+          }
 
-  &.large-filled-symbols ul.steps-indicator {
-    @include wz-define-style($layout, $border-width: 0) {
-      @include wz-state-circle-with-background-and-content($wz-param-indicator-color);
-    }
-  }
+          @else if $indicator-style == 'large-empty' {
+            @include wz-define-style($layout) {
+              border-width: $wz-param-indicator-border-width;
+              border-style: solid;
+              border-color: wz-get-color($indicator-style, $wz-param-step-state, $wz-param-indicator-state, 'border-color');
+            }
+          }
 
-  &.large-empty-symbols ul.steps-indicator {
-    @include wz-define-style($layout) {
-      @include wz-state-circle-with-border-and-content($wz-param-indicator-color);
+          @else if $indicator-style == 'large-filled-symbols' {
+            @include wz-define-style($layout, $border-width: 0) {
+              background-color: wz-get-color($indicator-style, $wz-param-step-state, $wz-param-indicator-state, 'background-color');
+              color: wz-get-color($indicator-style, $wz-param-step-state, $wz-param-indicator-state, 'symbol-color');
+            }
+          }
+
+          @else if $indicator-style == 'large-empty-symbols' {
+            @include wz-define-style($layout) {
+              border-width: $wz-param-indicator-border-width;
+              border-style: solid;
+              border-color: wz-get-color($indicator-style, $wz-param-step-state, $wz-param-indicator-state, 'border-color');
+              color: wz-get-color($indicator-style, $wz-param-step-state, $wz-param-indicator-state, 'symbol-color');
+            }
+          }
+        }
+      }
     }
   }
 }
 
 
-// Helper mixin to define indicator styles for 'horizontal' and 'vertical' layouts
-@mixin wz-define-layout-styles() {
-  @each $layout in 'horizontal', 'vertical' {
-    aw-wizard-navigation-bar.#{$layout} {
-      @include wz-define-styles($layout);
+// Retrieve color from the color definitions map ($wz-colors)
+//
+// Arguments:
+//   $indicator-style: Indicator style: 'small', 'large-filled' etc.
+//   $step-state:      Wizard step state: small', 'large-filled' etc.
+//   $indicator-state: Indicator state: 'default' or 'hover'
+//   $property:        Property to retrieve: 'background-color', 'border-color', 'symbol-color'
+//
+// Returns:
+//   Color value like #E6E6E6 or `null` if
+//     - the requested property is not specified in the color definitions map
+//     - the corresponding color definitions map entry is explicit `null`
+//
+@function wz-get-color($indicator-style, $step-state, $indicator-state, $property) {
+  $maps: (
+    map-get(map-get($wz-colors, $indicator-style) or (), $step-state) or (),
+    map-get(map-get($wz-colors, $indicator-style) or (), '_') or (),
+    map-get(map-get($wz-colors, '_') or (), $step-state) or (),
+    map-get(map-get($wz-colors, '_') or (), '_') or (),
+  );
+  $key: '#{$property}-#{$indicator-state}';
+  @each $map in $maps {
+    @if map-has-key($map, $key) {
+      @return map-get($map, $key);
     }
   }
+  @return null;
 }
 
 
@@ -297,113 +308,117 @@ aw-wizard-navigation-bar {
   }
 }
 
-aw-wizard-navigation-bar.horizontal {
+@if 'horizontal' is in $wz-layouts {
+  aw-wizard-navigation-bar.horizontal {
 
-  ul.steps-indicator {
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
+    ul.steps-indicator {
+      display: flex;
+      flex-direction: row;
+      justify-content: center;
 
-    margin: 0;
-    width: 100%;
-    list-style: none;
+      margin: 0;
+      width: 100%;
+      list-style: none;
 
-    @mixin steps($number-of-components) {
-      &:before {
-        left: 100% / $number-of-components / 2;
-        right: 100% / $number-of-components / 2;
+      @mixin steps($number-of-components) {
+        &:before {
+          left: 100% / $number-of-components / 2;
+          right: 100% / $number-of-components / 2;
+        }
+
+        li {
+          width: 100% / $number-of-components;
+        }
+      }
+
+      &.steps-2 {
+        @include steps(2);
+      }
+
+      &.steps-3 {
+        @include steps(3);
+      }
+
+      &.steps-4 {
+        @include steps(4);
+      }
+
+      &.steps-5 {
+        @include steps(5);
+      }
+
+      &.steps-6 {
+        @include steps(6);
+      }
+
+      &.steps-7 {
+        @include steps(7);
+      }
+
+      &.steps-8 {
+        @include steps(8);
+      }
+
+      &.steps-9 {
+        @include steps(9);
+      }
+
+      &.steps-10 {
+        @include steps(10);
       }
 
       li {
-        width: 100% / $number-of-components;
-      }
-    }
-
-    &.steps-2 {
-      @include steps(2);
-    }
-
-    &.steps-3 {
-      @include steps(3);
-    }
-
-    &.steps-4 {
-      @include steps(4);
-    }
-
-    &.steps-5 {
-      @include steps(5);
-    }
-
-    &.steps-6 {
-      @include steps(6);
-    }
-
-    &.steps-7 {
-      @include steps(7);
-    }
-
-    &.steps-8 {
-      @include steps(8);
-    }
-
-    &.steps-9 {
-      @include steps(9);
-    }
-
-    &.steps-10 {
-      @include steps(10);
-    }
-
-    li {
-      margin: 0;
-      padding: 0;
-      text-align: center;
-
-      a .label {
-        display: inline-block;
-        padding-top: $wz-text-padding-bottom;
+        margin: 0;
+        padding: 0;
         text-align: center;
-      }
-    }
-  }
-}
 
-aw-wizard-navigation-bar.vertical {
-  max-width: 280px;
-  width: 20%;
-  height: 100%;
-  position: sticky;
-  top: 0;
-
-  ul.steps-indicator {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-
-    list-style: none;
-    margin: auto;
-
-    li {
-
-      &:not(:last-child) {
-        margin-bottom: 0;
-        padding-bottom: $wz-distance-between-steps;
-      }
-
-      a {
-        // center labels vertically
-        display: flex;
-        flex-direction: row;
-        align-items: center;
-
-        .label {
-          margin-left: $wz-text-margin-left;
-          text-align: left;
+        a .label {
+          display: inline-block;
+          padding-top: $wz-text-padding-bottom;
+          text-align: center;
         }
       }
     }
   }
 }
 
-@include wz-define-layout-styles();
+@if 'vertical' is in $wz-layouts {
+  aw-wizard-navigation-bar.vertical {
+    max-width: 280px;
+    width: 20%;
+    height: 100%;
+    position: sticky;
+    top: 0;
+
+    ul.steps-indicator {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+
+      list-style: none;
+      margin: auto;
+
+      li {
+
+        &:not(:last-child) {
+          margin-bottom: 0;
+          padding-bottom: $wz-distance-between-steps;
+        }
+
+        a {
+          // center labels vertically
+          display: flex;
+          flex-direction: row;
+          align-items: center;
+
+          .label {
+            margin-left: $wz-text-margin-left;
+            text-align: left;
+          }
+        }
+      }
+    }
+  }
+}
+
+@include wz-define-styles();

--- a/src/css/wizard-navigation-bar.scss
+++ b/src/css/wizard-navigation-bar.scss
@@ -11,14 +11,14 @@
 // - https://github.com/sass/sass/issues/871
 //
 // indicator state: 'default' or 'hover'
-$wz-param-indicator-state: null !global;
+$aw-param-indicator-state: null !global;
 
 // wizard step state: 'default', 'current', 'done' etc.
-$wz-param-step-state: null !global;
+$aw-param-step-state: null !global;
 
 
 // Defines the line that strings together circles representing wizard steps, in the horizontal layout
-@mixin wz-horizontal-line($dot-width, $dot-height, $line-color) {
+@mixin aw-horizontal-line($dot-width, $dot-height, $line-color) {
   background-color: $line-color;
   content: '';
   position: absolute;
@@ -29,7 +29,7 @@ $wz-param-step-state: null !global;
 }
 
 // Defines the line that strings together circles representing wizard steps, in the vertical layout
-@mixin wz-vertical-line($dot-width, $dot-height, $line-color) {
+@mixin aw-vertical-line($dot-width, $dot-height, $line-color) {
   background-color: $line-color;
   content: '';
   position: absolute;
@@ -40,7 +40,7 @@ $wz-param-step-state: null !global;
 }
 
 // Defines a circle representing a wizard step
-@mixin wz-circle($dot-width, $dot-height, $dot-border-width) {
+@mixin aw-circle($dot-width, $dot-height, $dot-border-width) {
   position: absolute;
   width: $dot-width;
   height: $dot-height;
@@ -52,13 +52,13 @@ $wz-param-step-state: null !global;
 }
 
 // Positions a circle in the horizontal layout of the navigation bar
-@mixin wz-circle-position-horizontal($dot-width, $dot-height, $dot-border-width) {
+@mixin aw-circle-position-horizontal($dot-width, $dot-height, $dot-border-width) {
   top: -$dot-height;
   left: calc(50% - #{$dot-width / 2});
 }
 
 // Positions a circle in the vertical layout of the navigation bar
-@mixin wz-circle-position-vertical($dot-width, $dot-height, $dot-border-width) {
+@mixin aw-circle-position-vertical($dot-width, $dot-height, $dot-border-width) {
   top: 0;
   left: -$dot-width;
 }
@@ -75,37 +75,37 @@ $wz-param-step-state: null !global;
 // which is applied for .step-indicator elements and is expected to customize indicator representation.
 // The content block is invoked several times, each time with different arguments passed through global variables:
 //
-//   - $wz-param-indicator-state - indicator state: 'default' or 'hover'
-//   - $wz-param-step-state - wizard step state: 'default', 'current', 'done' etc.
+//   - $aw-param-indicator-state - indicator state: 'default' or 'hover'
+//   - $aw-param-step-state - wizard step state: 'default', 'current', 'done' etc.
 //
 // In addition to these variables, the content block can use the following
 // variables passed through the `define-style` mixin:
 //
-//   - $wz-param-indicator-width - equals to $width argument of the `define-style` mixin
-//   - $wz-param-indicator-height - equals to $height argument of the `define-style` mixin
-//   - $wz-param-indicator-border-width - equals to $border-width argument of the `define-style` mixin
+//   - $aw-param-indicator-width - equals to $width argument of the `define-style` mixin
+//   - $aw-param-indicator-height - equals to $height argument of the `define-style` mixin
+//   - $aw-param-indicator-border-width - equals to $border-width argument of the `define-style` mixin
 //
-@mixin wz-define-style($layout, $width: $wz-big-dot-height, $height: $wz-big-dot-height, $border-width: $wz-dot-border-width) {
+@mixin aw-define-style($layout, $width: $aw-big-dot-height, $height: $aw-big-dot-height, $border-width: $aw-dot-border-width) {
 
   // Make variables accessible from the content block
-  $wz-param-indicator-width: $width !global;
-  $wz-param-indicator-height: $height !global;
-  $wz-param-indicator-border-width: $border-width !global;
+  $aw-param-indicator-width: $width !global;
+  $aw-param-indicator-height: $height !global;
+  $aw-param-indicator-border-width: $border-width !global;
 
   @if ($layout == 'horizontal') {
-    padding: ($height + $wz-text-padding-bottom) 0 $wz-text-padding-bottom 0;
+    padding: ($height + $aw-text-padding-bottom) 0 $aw-text-padding-bottom 0;
   }
   @else if ($layout == 'vertical') {
-    padding: ($wz-distance-between-steps / 2) ($wz-distance-between-steps / 2) ($wz-distance-between-steps / 2) ($wz-distance-between-steps / 2 + $height);
+    padding: ($aw-distance-between-steps / 2) ($aw-distance-between-steps / 2) ($aw-distance-between-steps / 2) ($aw-distance-between-steps / 2 + $height);
   }
 
   li {
     &:not(:last-child):before {
       @if ($layout == 'horizontal') {
-        @include wz-horizontal-line($width, $height, $wz-line-color);
+        @include aw-horizontal-line($width, $height, $aw-line-color);
       }
       @else if ($layout == 'vertical') {
-        @include wz-vertical-line($width, $height, $wz-line-color);
+        @include aw-vertical-line($width, $height, $aw-line-color);
       }
     }
 
@@ -117,133 +117,133 @@ $wz-param-step-state: null !global;
 
     .step-indicator {
       @if ($layout == 'horizontal') {
-        @include wz-circle-position-horizontal($width, $height, $border-width);
+        @include aw-circle-position-horizontal($width, $height, $border-width);
       }
       @else if ($layout == 'vertical') {
-        @include wz-circle-position-vertical($width, $height, $border-width);
+        @include aw-circle-position-vertical($width, $height, $border-width);
       }
 
-      $wz-param-indicator-state: 'default' !global;
-      $wz-param-step-state: 'default' !global;
-      @include wz-circle($width, $height, $border-width);
+      $aw-param-indicator-state: 'default' !global;
+      $aw-param-step-state: 'default' !global;
+      @include aw-circle($width, $height, $border-width);
       @content;
     }
     &.optional .step-indicator {
-      $wz-param-indicator-state: 'default' !global;
-      $wz-param-step-state: 'optional' !global;
+      $aw-param-indicator-state: 'default' !global;
+      $aw-param-step-state: 'optional' !global;
       @content;
     }
     &.done .step-indicator {
-      $wz-param-indicator-state: 'default' !global;
-      $wz-param-step-state: 'done' !global;
+      $aw-param-indicator-state: 'default' !global;
+      $aw-param-step-state: 'done' !global;
       @content;
     }
     &.current .step-indicator {
-      $wz-param-indicator-state: 'default' !global;
-      $wz-param-step-state: 'current' !global;
+      $aw-param-indicator-state: 'default' !global;
+      $aw-param-step-state: 'current' !global;
       @content;
     }
     &.editing .step-indicator {
-      $wz-param-indicator-state: 'default' !global;
-      $wz-param-step-state: 'editing' !global;
+      $aw-param-indicator-state: 'default' !global;
+      $aw-param-step-state: 'editing' !global;
       @content;
     }
     // 'completed' class takes priority
     // https://github.com/madoar/angular-archwizard/pull/221
     &.completed .step-indicator {
-      $wz-param-indicator-state: 'default' !global;
-      $wz-param-step-state: 'done' !global;
+      $aw-param-indicator-state: 'default' !global;
+      $aw-param-step-state: 'done' !global;
       @content;
     }
 
     &.navigable a:hover .step-indicator {
-      $wz-param-indicator-state: 'hover' !global;
-      $wz-param-step-state: 'default' !global;
-      @include wz-circle($width, $height, $border-width);
+      $aw-param-indicator-state: 'hover' !global;
+      $aw-param-step-state: 'default' !global;
+      @include aw-circle($width, $height, $border-width);
       @content;
     }
     &.navigable.optional a:hover .step-indicator {
-      $wz-param-indicator-state: 'hover' !global;
-      $wz-param-step-state: 'optional' !global;
+      $aw-param-indicator-state: 'hover' !global;
+      $aw-param-step-state: 'optional' !global;
       @content;
     }
     &.navigable.done a:hover .step-indicator {
-      $wz-param-indicator-state: 'hover' !global;
-      $wz-param-step-state: 'done' !global;
+      $aw-param-indicator-state: 'hover' !global;
+      $aw-param-step-state: 'done' !global;
       @content;
     }
     &.navigable.current a:hover .step-indicator {
-      $wz-param-indicator-state: 'hover' !global;
-      $wz-param-step-state: 'current' !global;
+      $aw-param-indicator-state: 'hover' !global;
+      $aw-param-step-state: 'current' !global;
       @content;
     }
     &.navigable.editing a:hover .step-indicator {
-      $wz-param-indicator-state: 'hover' !global;
-      $wz-param-step-state: 'editing' !global;
+      $aw-param-indicator-state: 'hover' !global;
+      $aw-param-step-state: 'editing' !global;
       @content;
     }
     // 'completed' class takes priority
     // https://github.com/madoar/angular-archwizard/pull/221
     &.navigable.completed a:hover .step-indicator {
-      $wz-param-indicator-state: 'hover' !global;
-      $wz-param-step-state: 'done' !global;
+      $aw-param-indicator-state: 'hover' !global;
+      $aw-param-step-state: 'done' !global;
       @content;
     }
   }
 }
 
 
-// Define wizard styles specific to the configurated layouts (`$wz-layouts`) and indicator styles (`$wz-indicator-styles`)
-@mixin wz-define-styles() {
+// Define wizard styles specific to the configurated layouts (`$aw-layouts`) and indicator styles (`$aw-indicator-styles`)
+@mixin aw-define-styles() {
 
   // For each layout and indicator style...
-  @each $layout in $wz-layouts {
+  @each $layout in $aw-layouts {
     aw-wizard-navigation-bar.#{$layout} {
-      @each $indicator-style in $wz-indicator-styles {
+      @each $indicator-style in $aw-indicator-styles {
         &.#{$indicator-style} ul.steps-indicator {
           // ...we are emitting CSS styles for `aw-wizard-navigation-bar.<layout>.<indicator-style> ul.steps-indicator`
 
           // Each indicator style is defined with its specific values (like `$border-width: 0` in this case) and CSS
           // properties.  For indicator style 'small' we only define background color, while for other indicator styles
-          // below we define border and/or color properties.  The `wz-define-style` mixin here is used to apply CSS
+          // below we define border and/or color properties.  The `aw-define-style` mixin here is used to apply CSS
           // properties in a proper order for each wizard step state ('default', 'current', 'done' etc.)
           @if $indicator-style == 'small' {
-            @include wz-define-style($layout, $width: $wz-small-dot-width, $height: $wz-small-dot-height, $border-width: 0) {
-              background-color: wz-get-color($indicator-style, $wz-param-step-state, $wz-param-indicator-state, 'background-color');
+            @include aw-define-style($layout, $width: $aw-small-dot-width, $height: $aw-small-dot-height, $border-width: 0) {
+              background-color: aw-get-color($indicator-style, $aw-param-step-state, $aw-param-indicator-state, 'background-color');
             }
           }
 
           @else if $indicator-style == 'large-filled' {
-            @include wz-define-style($layout, $border-width: 0) {
-              background-color: wz-get-color($indicator-style, $wz-param-step-state, $wz-param-indicator-state, 'background-color');
+            @include aw-define-style($layout, $border-width: 0) {
+              background-color: aw-get-color($indicator-style, $aw-param-step-state, $aw-param-indicator-state, 'background-color');
             }
           }
 
           @else if $indicator-style == 'large-empty' {
-            @include wz-define-style($layout) {
-              $border-color: wz-get-color($indicator-style, $wz-param-step-state, $wz-param-indicator-state, 'border-color');
+            @include aw-define-style($layout) {
+              $border-color: aw-get-color($indicator-style, $aw-param-step-state, $aw-param-indicator-state, 'border-color');
               @if $border-color != null {
                 // To optimize CSS output size, do not define any border styles when border-color is null
-                border: $wz-param-indicator-border-width solid $border-color;
+                border: $aw-param-indicator-border-width solid $border-color;
               }
             }
           }
 
           @else if $indicator-style == 'large-filled-symbols' {
-            @include wz-define-style($layout, $border-width: 0) {
-              background-color: wz-get-color($indicator-style, $wz-param-step-state, $wz-param-indicator-state, 'background-color');
-              color: wz-get-color($indicator-style, $wz-param-step-state, $wz-param-indicator-state, 'symbol-color');
+            @include aw-define-style($layout, $border-width: 0) {
+              background-color: aw-get-color($indicator-style, $aw-param-step-state, $aw-param-indicator-state, 'background-color');
+              color: aw-get-color($indicator-style, $aw-param-step-state, $aw-param-indicator-state, 'symbol-color');
             }
           }
 
           @else if $indicator-style == 'large-empty-symbols' {
-            @include wz-define-style($layout) {
-              $border-color: wz-get-color($indicator-style, $wz-param-step-state, $wz-param-indicator-state, 'border-color');
+            @include aw-define-style($layout) {
+              $border-color: aw-get-color($indicator-style, $aw-param-step-state, $aw-param-indicator-state, 'border-color');
               @if $border-color != null {
                 // To optimize CSS output size, do not define any border styles when border-color is null
-                border: $wz-param-indicator-border-width solid $border-color;
+                border: $aw-param-indicator-border-width solid $border-color;
               }
-              color: wz-get-color($indicator-style, $wz-param-step-state, $wz-param-indicator-state, 'symbol-color');
+              color: aw-get-color($indicator-style, $aw-param-step-state, $aw-param-indicator-state, 'symbol-color');
             }
           }
         }
@@ -253,7 +253,7 @@ $wz-param-step-state: null !global;
 }
 
 
-// Retrieve color from the color definitions map ($wz-colors)
+// Retrieve color from the color definitions map ($aw-colors)
 //
 // Arguments:
 //   $indicator-style: Indicator style: 'small', 'large-filled' etc.
@@ -266,23 +266,23 @@ $wz-param-step-state: null !global;
 //     - the requested property is not specified in the color definitions map
 //     - the corresponding color definitions map entry is explicit `null`
 //
-@function wz-get-color($indicator-style, $step-state, $indicator-state, $property) {
+@function aw-get-color($indicator-style, $step-state, $indicator-state, $property) {
   //
   // Gather a list of candidate maps to search for the requested property.
   // As documented in archwizard.scss, "Default Colors" section, the order should be as follows:
   //
-  // - $wz-colors[$indicator-style][$step-state][$color]
-  // - $wz-colors[$indicator-style]['_'][$color]
-  // - $wz-colors['_'][$step-state][$color]
-  // - $wz-colors['_']['_'][$color]
+  // - $aw-colors[$indicator-style][$step-state][$color]
+  // - $aw-colors[$indicator-style]['_'][$color]
+  // - $aw-colors['_'][$step-state][$color]
+  // - $aw-colors['_']['_'][$color]
   //
   // Additional "or ()" expressions are necessary because calling `map-get(null)` causes an SCSS compilation error
   //
   $maps: (
-    map-get(map-get($wz-colors, $indicator-style) or (), $step-state) or (),
-    map-get(map-get($wz-colors, $indicator-style) or (), '_') or (),
-    map-get(map-get($wz-colors, '_') or (), $step-state) or (),
-    map-get(map-get($wz-colors, '_') or (), '_') or (),
+    map-get(map-get($aw-colors, $indicator-style) or (), $step-state) or (),
+    map-get(map-get($aw-colors, $indicator-style) or (), '_') or (),
+    map-get(map-get($aw-colors, '_') or (), $step-state) or (),
+    map-get(map-get($aw-colors, '_') or (), '_') or (),
   );
 
   // Loop through $maps until we find the requested property
@@ -312,9 +312,9 @@ aw-wizard-navigation-bar {
       pointer-events: none;
 
       a .label {
-        color: $wz-label-color-default;
-        line-height: $wz-text-height;
-        font-size: $wz-text-height;
+        color: $aw-label-color-default;
+        line-height: $aw-text-height;
+        font-size: $aw-text-height;
         text-decoration: none;
         text-transform: uppercase;
         font-weight: bold;
@@ -330,13 +330,13 @@ aw-wizard-navigation-bar {
       }
 
       a:hover .label {
-        color: $wz-label-color-hover;
+        color: $aw-label-color-hover;
       }
     }
   }
 }
 
-@if 'horizontal' is in $wz-layouts {
+@if 'horizontal' is in $aw-layouts {
   aw-wizard-navigation-bar.horizontal {
 
     ul.steps-indicator {
@@ -368,7 +368,7 @@ aw-wizard-navigation-bar {
 
         a .label {
           display: inline-block;
-          padding-top: $wz-text-padding-bottom;
+          padding-top: $aw-text-padding-bottom;
           text-align: center;
         }
       }
@@ -376,7 +376,7 @@ aw-wizard-navigation-bar {
   }
 }
 
-@if 'vertical' is in $wz-layouts {
+@if 'vertical' is in $aw-layouts {
   aw-wizard-navigation-bar.vertical {
     max-width: 280px;
     width: 20%;
@@ -396,7 +396,7 @@ aw-wizard-navigation-bar {
 
         &:not(:last-child) {
           margin-bottom: 0;
-          padding-bottom: $wz-distance-between-steps;
+          padding-bottom: $aw-distance-between-steps;
         }
 
         a {
@@ -406,7 +406,7 @@ aw-wizard-navigation-bar {
           align-items: center;
 
           .label {
-            margin-left: $wz-text-margin-left;
+            margin-left: $aw-text-margin-left;
             text-align: left;
           }
         }
@@ -415,4 +415,4 @@ aw-wizard-navigation-bar {
   }
 }
 
-@include wz-define-styles();
+@include aw-define-styles();

--- a/src/css/wizard-navigation-bar.scss
+++ b/src/css/wizard-navigation-bar.scss
@@ -320,51 +320,17 @@ aw-wizard-navigation-bar {
       width: 100%;
       list-style: none;
 
-      @mixin steps($number-of-components) {
-        &:before {
-          left: 100% / $number-of-components / 2;
-          right: 100% / $number-of-components / 2;
+      @for $number-of-components from 2 through 10 {
+        &.steps-#{$number-of-components} {
+          &:before {
+            left: 100% / $number-of-components / 2;
+            right: 100% / $number-of-components / 2;
+          }
+
+          li {
+            width: 100% / $number-of-components;
+          }
         }
-
-        li {
-          width: 100% / $number-of-components;
-        }
-      }
-
-      &.steps-2 {
-        @include steps(2);
-      }
-
-      &.steps-3 {
-        @include steps(3);
-      }
-
-      &.steps-4 {
-        @include steps(4);
-      }
-
-      &.steps-5 {
-        @include steps(5);
-      }
-
-      &.steps-6 {
-        @include steps(6);
-      }
-
-      &.steps-7 {
-        @include steps(7);
-      }
-
-      &.steps-8 {
-        @include steps(8);
-      }
-
-      &.steps-9 {
-        @include steps(9);
-      }
-
-      &.steps-10 {
-        @include steps(10);
       }
 
       li {

--- a/src/css/wizard-navigation-bar.scss
+++ b/src/css/wizard-navigation-bar.scss
@@ -17,6 +17,7 @@ $wz-param-indicator-state: null !global;
 $wz-param-step-state: null !global;
 
 
+// Defines the line that strings together circles representing wizard steps, in the horizontal layout
 @mixin wz-horizontal-line($dot-width, $dot-height, $line-color) {
   background-color: $line-color;
   content: '';
@@ -27,6 +28,7 @@ $wz-param-step-state: null !global;
   left: calc(50% + #{$dot-width / 2});
 }
 
+// Defines the line that strings together circles representing wizard steps, in the vertical layout
 @mixin wz-vertical-line($dot-width, $dot-height, $line-color) {
   background-color: $line-color;
   content: '';
@@ -37,16 +39,7 @@ $wz-param-step-state: null !global;
   width: 1px;
 }
 
-@mixin wz-circle-position-horizontal($dot-width, $dot-height, $dot-border-width) {
-  top: -$dot-height;
-  left: calc(50% - #{$dot-width / 2});
-}
-
-@mixin wz-circle-position-vertical($dot-width, $dot-height, $dot-border-width) {
-  top: 0;
-  left: -$dot-width;
-}
-
+// Defines a circle representing a wizard step
 @mixin wz-circle($dot-width, $dot-height, $dot-border-width) {
   position: absolute;
   width: $dot-width;
@@ -58,6 +51,17 @@ $wz-param-step-state: null !global;
   border-radius: 100%;
 }
 
+// Positions a circle in the horizontal layout of the navigation bar
+@mixin wz-circle-position-horizontal($dot-width, $dot-height, $dot-border-width) {
+  top: -$dot-height;
+  left: calc(50% - #{$dot-width / 2});
+}
+
+// Positions a circle in the vertical layout of the navigation bar
+@mixin wz-circle-position-vertical($dot-width, $dot-height, $dot-border-width) {
+  top: 0;
+  left: -$dot-width;
+}
 
 // Define a step indicator style like 'small', 'large-filled' etc.
 //

--- a/src/css/wizard-navigation-bar.scss
+++ b/src/css/wizard-navigation-bar.scss
@@ -246,7 +246,7 @@ $wz-param-step-state: null !global;
 //
 // Arguments:
 //   $indicator-style: Indicator style: 'small', 'large-filled' etc.
-//   $step-state:      Wizard step state: small', 'large-filled' etc.
+//   $step-state:      Wizard step state: 'default', 'current', 'done' etc.
 //   $indicator-state: Indicator state: 'default' or 'hover'
 //   $property:        Property to retrieve: 'background-color', 'border-color', 'symbol-color'
 //

--- a/src/css/wizard-navigation-bar.scss
+++ b/src/css/wizard-navigation-bar.scss
@@ -118,10 +118,10 @@ $wz-param-indicator-color: null !global;
   li {
     &:not(:last-child):before {
       @if ($layout == 'horizontal') {
-        @include wz-horizontal-line($width, $height, $wz-color-default);
+        @include wz-horizontal-line($width, $height, $wz-line-color);
       }
       @else if ($layout == 'vertical') {
-        @include wz-vertical-line($width, $height, $wz-color-default);
+        @include wz-vertical-line($width, $height, $wz-line-color);
       }
     }
 

--- a/src/css/wizard-navigation-bar.scss
+++ b/src/css/wizard-navigation-bar.scss
@@ -85,7 +85,7 @@ $aw-param-step-state: null !global;
 //   - $aw-param-indicator-height - equals to $height argument of the `define-style` mixin
 //   - $aw-param-indicator-border-width - equals to $border-width argument of the `define-style` mixin
 //
-@mixin aw-define-style($layout, $width: $aw-big-dot-height, $height: $aw-big-dot-height, $border-width: $aw-dot-border-width) {
+@mixin aw-define-style($layout, $width: $aw-big-circle-height, $height: $aw-big-circle-height, $border-width: $aw-circle-border-width) {
 
   // Make variables accessible from the content block
   $aw-param-indicator-width: $width !global;
@@ -208,7 +208,7 @@ $aw-param-step-state: null !global;
           // below we define border and/or color properties.  The `aw-define-style` mixin here is used to apply CSS
           // properties in a proper order for each wizard step state ('default', 'current', 'done' etc.)
           @if $indicator-style == 'small' {
-            @include aw-define-style($layout, $width: $aw-small-dot-width, $height: $aw-small-dot-height, $border-width: 0) {
+            @include aw-define-style($layout, $width: $aw-small-circle-width, $height: $aw-small-circle-height, $border-width: 0) {
               background-color: aw-get-color($indicator-style, $aw-param-step-state, $aw-param-indicator-state, 'background-color');
             }
           }

--- a/src/css/wizard-navigation-bar.scss
+++ b/src/css/wizard-navigation-bar.scss
@@ -256,12 +256,25 @@ $wz-param-step-state: null !global;
 //     - the corresponding color definitions map entry is explicit `null`
 //
 @function wz-get-color($indicator-style, $step-state, $indicator-state, $property) {
+  //
+  // Gather a list of candidate maps to search for the requested property.
+  // As documented in archwizard.scss, "Default Colors" section, the order should be as follows:
+  //
+  // - $wz-colors[$indicator-style][$step-state][$color]
+  // - $wz-colors[$indicator-style]['_'][$color]
+  // - $wz-colors['_'][$step-state][$color]
+  // - $wz-colors['_']['_'][$color]
+  //
+  // Additional "or ()" expressions are necessary because calling `map-get(null)` causes an SCSS compilation error
+  //
   $maps: (
     map-get(map-get($wz-colors, $indicator-style) or (), $step-state) or (),
     map-get(map-get($wz-colors, $indicator-style) or (), '_') or (),
     map-get(map-get($wz-colors, '_') or (), $step-state) or (),
     map-get(map-get($wz-colors, '_') or (), '_') or (),
   );
+
+  // Loop through $maps until we find the requested property
   $key: '#{$property}-#{$indicator-state}';
   @each $map in $maps {
     @if map-has-key($map, $key) {

--- a/src/css/wizard-navigation-bar.scss
+++ b/src/css/wizard-navigation-bar.scss
@@ -191,11 +191,18 @@ $wz-param-step-state: null !global;
 
 // Define wizard styles specific to the configurated layouts (`$wz-layouts`) and indicator styles (`$wz-indicator-styles`)
 @mixin wz-define-styles() {
+
+  // For each layout and indicator style...
   @each $layout in $wz-layouts {
     aw-wizard-navigation-bar.#{$layout} {
       @each $indicator-style in $wz-indicator-styles {
         &.#{$indicator-style} ul.steps-indicator {
+          // ...we are emitting CSS styles for `aw-wizard-navigation-bar.<layout>.<indicator-style> ul.steps-indicator`
 
+          // Each indicator style is defined with its specific values (like `$border-width: 0` in this case) and CSS
+          // properties.  For indicator style 'small' we only define background color, while for other indicator styles
+          // below we define border and/or color properties.  The `wz-define-style` mixin here is used to apply CSS
+          // properties in a proper order for each wizard step state ('default', 'current', 'done' etc.)
           @if $indicator-style == 'small' {
             @include wz-define-style($layout, $width: $wz-small-dot-width, $height: $wz-small-dot-height, $border-width: 0) {
               background-color: wz-get-color($indicator-style, $wz-param-step-state, $wz-param-indicator-state, 'background-color');

--- a/src/css/wizard-navigation-bar.scss
+++ b/src/css/wizard-navigation-bar.scss
@@ -210,9 +210,11 @@ $wz-param-step-state: null !global;
 
           @else if $indicator-style == 'large-empty' {
             @include wz-define-style($layout) {
-              border-width: $wz-param-indicator-border-width;
-              border-style: solid;
-              border-color: wz-get-color($indicator-style, $wz-param-step-state, $wz-param-indicator-state, 'border-color');
+              $border-color: wz-get-color($indicator-style, $wz-param-step-state, $wz-param-indicator-state, 'border-color');
+              @if $border-color != null {
+                // To optimize CSS output size, do not define any border styles when border-color is null
+                border: $wz-param-indicator-border-width solid $border-color;
+              }
             }
           }
 
@@ -225,9 +227,11 @@ $wz-param-step-state: null !global;
 
           @else if $indicator-style == 'large-empty-symbols' {
             @include wz-define-style($layout) {
-              border-width: $wz-param-indicator-border-width;
-              border-style: solid;
-              border-color: wz-get-color($indicator-style, $wz-param-step-state, $wz-param-indicator-state, 'border-color');
+              $border-color: wz-get-color($indicator-style, $wz-param-step-state, $wz-param-indicator-state, 'border-color');
+              @if $border-color != null {
+                // To optimize CSS output size, do not define any border styles when border-color is null
+                border: $wz-param-indicator-border-width solid $border-color;
+              }
               color: wz-get-color($indicator-style, $wz-param-step-state, $wz-param-indicator-state, 'symbol-color');
             }
           }

--- a/src/css/wizard-navigation-bar.scss
+++ b/src/css/wizard-navigation-bar.scss
@@ -273,7 +273,7 @@ aw-wizard-navigation-bar {
       pointer-events: none;
 
       a .label {
-        color: $wz-color-current;
+        color: $wz-label-color-default;
         line-height: $wz-text-height;
         font-size: $wz-text-height;
         text-decoration: none;
@@ -291,7 +291,7 @@ aw-wizard-navigation-bar {
       }
 
       a:hover .label {
-        color: darken($wz-color-current, 20%);
+        color: $wz-label-color-hover;
       }
     }
   }


### PR DESCRIPTION
Hello @madoar ,

It is usually considered a good practice of visual design to restrict colors used in the application UI to a limited subset which might be called a palette or a theme. In some cases, such theme lists not only base colors, but also their shades from light to dark to be used in different parts of the UI.

Version 5.0.0 of angular-archwizard exposes SCSS variables which can be used for customizing base colors of the wizard. However, things like using `darken(…, 10%)` to derive a hover color from a base color are still hard coded and hard for a library user to override.

This PR extends angular-archwizard's style customization support. Instead of a small number of variables controlling base colors (`$wz-color-default`, …, `$wz-color-editing`) it exposes a complex `$wz-colors` structure that completely defines a color scheme to be used for navbar indicators, including colors for hovered state.

As an auxiliary change, the updated `*.scss` file also exposes `$wz-layouts` and `$wz-indicator-styles` variables. Library users can override these to exclude unused layouts and indicator style and thus optimize CSS output size.

Notes:
- I have been using this modified version of angular-wizard in order to customize its colors for our project.
- This PR introduces incompatible changes for those who already customize wizard's appearance using SCSS. For other users, changes will go unnoticed. As a matter of fact, this PR does not introduce _any_ meaningful changes in the CSS file included into angular-archwizard npm package.

<a href="https://gitpod.io/#https://github.com/madoar/angular-archwizard/pull/235"><img src="https://gitpod.io/api/apps/github/pbs/github.com/earshinov/angular-archwizard.git/65ba9406a3c02f8bd78029f78fef0a2290f02253.svg" /></a>

