### PR TITLE
Change :before to :after

### DIFF
--- a/src/css/wizard-navigation-bar.scss
+++ b/src/css/wizard-navigation-bar.scss
@@ -100,7 +100,7 @@ $aw-param-step-state: null;
   }
 
   li {
-    &:not(:last-child):before {
+    &:not(:last-child):after {
       @if ($layout == 'horizontal') {
         @include aw-horizontal-line($width, $height, $aw-line-color);
       }
@@ -350,7 +350,7 @@ aw-wizard-navigation-bar {
 
       @for $number-of-components from 2 through 10 {
         &.steps-#{$number-of-components} {
-          &:before {
+          &:after {
             left: 100% / $number-of-components / 2;
             right: 100% / $number-of-components / 2;
           }


### PR DESCRIPTION
This changes the usage of `:before` to `:after` and closes #249

<a href="https://gitpod.io/#https://github.com/madoar/angular-archwizard/pull/252"><img src="https://gitpod.io/api/apps/github/pbs/github.com/madoar/angular-archwizard.git/2491eebdd5a0ebc567f110051625837f763cb6b1.svg" /></a>

