### PR TITLE
Inject the WizardStep in the "ng-template" Environment of the "awWizardStepSymbol" and "awWizardStepTitle" Directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,17 @@ This can be achieved by using the `[awWizardStepTitle]` directive inside a wizar
 </aw-wizard-step>
 ```
 
+Additionally it is possible to inject the corresponding `WizardStep` object into the `ng-template` environment.
+This for example allows customization of the step title depending on the state of the wizard step, like on the completion and selection state:
+
+```html
+<aw-wizard-step (stepEnter)="enterStep($event)">
+  <ng-template awWizardStepTitle let-wizardStep="wizardStep">
+    {{ wizardStep.completed ? "Delivery address (✔)" : "Delivery address" }}
+  </ng-template>
+</aw-wizard-step>
+```
+
 ### \[awWizardStepSymbol\]
 In addition to the step title, the navigation symbol/step symbol can also be set via a directive.
 This is required, if the navigation step symbol is not a simple character or a symbol, but something more complex, like a html component.
@@ -361,6 +372,18 @@ In such a case, the the navigation symbol can be specified using the `[awWizardS
 <aw-wizard-step (stepEnter)="enterStep($event)">
   <ng-template awWizardStepSymbol>
     <i class="far fa-file"></i>
+  </ng-template>
+</aw-wizard-step>
+```
+
+Additionally it is possible to inject the corresponding `WizardStep` object into the `ng-template` environment.
+This for example allows customization of the navigation symbol depending on the state of the wizard step, like on the completion and selection state:
+
+```html
+<aw-wizard-step (stepEnter)="enterStep($event)">
+  <ng-template awWizardStepSymbol let-wizardStep="wizardStep">
+    <i *ngIf="!wizardStep.completed" class="far fa-file"></i>
+    <i *ngIf="wizardStep.completed" class="far fa-check"></i>
   </ng-template>
 </aw-wizard-step>
 ```

--- a/src/lib/components/wizard-navigation-bar.component.html
+++ b/src/lib/components/wizard-navigation-bar.component.html
@@ -1,6 +1,5 @@
 <ul class="steps-indicator steps-{{numberOfWizardSteps}}">
-  <li [attr.id]="step.stepId" *ngFor="let step of wizardSteps"
-      [ngClass]="{
+  <li [attr.id]="step.stepId" *ngFor="let step of wizardSteps" [ngClass]="{
         current: isCurrent(step),
         editing: isEditing(step),
         done: isDone(step),
@@ -10,11 +9,14 @@
   }">
     <a [awGoToStep]="step">
       <div class="label">
-        <ng-container *ngIf="step.stepTitleTemplate" [ngTemplateOutlet]="step.stepTitleTemplate.templateRef"></ng-container>
+        <ng-container *ngIf="step.stepTitleTemplate" [ngTemplateOutlet]="step.stepTitleTemplate.templateRef"
+          [ngTemplateOutletContext]="{wizardStep: step}"></ng-container>
         <ng-container *ngIf="!step.stepTitleTemplate">{{step.stepTitle}}</ng-container>
       </div>
-      <div class="step-indicator" [ngStyle]="{ 'font-family': step.stepSymbolTemplate ? '' : step.navigationSymbol.fontFamily }">
-        <ng-container *ngIf="step.stepSymbolTemplate" [ngTemplateOutlet]="step.stepSymbolTemplate.templateRef"></ng-container>
+      <div class="step-indicator"
+        [ngStyle]="{ 'font-family': step.stepSymbolTemplate ? '' : step.navigationSymbol.fontFamily }">
+        <ng-container *ngIf="step.stepSymbolTemplate" [ngTemplateOutlet]="step.stepSymbolTemplate.templateRef"
+          [ngTemplateOutletContext]="{wizardStep: step}"></ng-container>
         <ng-container *ngIf="!step.stepSymbolTemplate">{{step.navigationSymbol.symbol}}</ng-container>
       </div>
     </a>

--- a/src/lib/directives/wizard-step-symbol.directive.spec.ts
+++ b/src/lib/directives/wizard-step-symbol.directive.spec.ts
@@ -1,36 +1,45 @@
 import {Component, ViewChild} from '@angular/core';
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {ArchwizardModule} from '../archwizard.module';
 import {WizardComponent} from '../components/wizard.component';
+import {checkWizardState} from '../util/test-utils';
 
 @Component({
   selector: 'aw-test-wizard',
   template: `
     <aw-wizard>
       <aw-wizard-step stepTitle='Step A'>
-        <ng-template awWizardStepSymbol>
-          A
+        <ng-template awWizardStepSymbol let-wizardStep="wizardStep">
+          {{ wizardStep.completed ? 'D' : '' }}{{ wizardStep.editing ? 'E' : '' }}{{ wizardStep.selected ? 'S' : '' }}A
         </ng-template>
         Step A content
       </aw-wizard-step>
-      <aw-wizard-completion-step stepTitle='Step B'>
+      <aw-wizard-step stepTitle='Step B'>
         <ng-template awWizardStepSymbol>
           B
         </ng-template>
         Step B content
+      </aw-wizard-step>
+      <aw-wizard-completion-step stepTitle='Step C'>
+        <ng-template awWizardStepSymbol>
+          C
+        </ng-template>
+        Step C content
       </aw-wizard-completion-step>
     </aw-wizard>
   `
 })
 class WizardTestComponent {
-  @ViewChild(WizardComponent, {static: false})
+  @ViewChild(WizardComponent, { static: false })
   public wizard: WizardComponent;
 }
 
 describe('WizardStepSymbolDirective', () => {
-  let wizardTest: WizardTestComponent;
   let wizardTestFixture: ComponentFixture<WizardTestComponent>;
+
+  let wizardTest: WizardTestComponent;
+  let wizard: WizardComponent;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -44,13 +53,78 @@ describe('WizardStepSymbolDirective', () => {
     wizardTestFixture.detectChanges();
 
     wizardTest = wizardTestFixture.componentInstance;
+    wizard = wizardTest.wizard;
   });
 
   it('should create an instance', () => {
     const navigationSymbolEls = wizardTestFixture.debugElement.queryAll(By.css('aw-wizard-navigation-bar ul li .step-indicator'));
 
-    expect(navigationSymbolEls.length).toBe(2);
-    expect(navigationSymbolEls[0].nativeElement.textContent.trim()).toBe('A');
+    checkWizardState(wizard, 0, false, [], false);
+
+    expect(navigationSymbolEls.length).toBe(3);
+    expect(navigationSymbolEls[0].nativeElement.textContent.trim()).toBe('SA');
     expect(navigationSymbolEls[1].nativeElement.textContent.trim()).toBe('B');
+    expect(navigationSymbolEls[2].nativeElement.textContent.trim()).toBe('C');
   });
+
+  it('should change first navigation symbol correctly upon completion state change', fakeAsync(() => {
+    const navigationSymbolEls = wizardTestFixture.debugElement.queryAll(By.css('aw-wizard-navigation-bar ul li .step-indicator'));
+
+    // go to second step
+    wizard.goToNextStep();
+    tick();
+    wizardTestFixture.detectChanges();
+
+    checkWizardState(wizard, 1, false, [0], false);
+
+    // "SA" should become "DA"
+    expect(navigationSymbolEls.length).toBe(3);
+    expect(navigationSymbolEls[0].nativeElement.textContent.trim()).toBe('DA');
+    expect(navigationSymbolEls[1].nativeElement.textContent.trim()).toBe('B');
+    expect(navigationSymbolEls[2].nativeElement.textContent.trim()).toBe('C');
+  }));
+
+  it('should change first navigation symbol correctly upon editing state change', fakeAsync(() => {
+    const navigationSymbolEls = wizardTestFixture.debugElement.queryAll(By.css('aw-wizard-navigation-bar ul li .step-indicator'));
+
+    // go to second step
+    wizard.goToNextStep();
+    tick();
+    wizardTestFixture.detectChanges();
+
+    // go to first step
+    wizard.goToPreviousStep();
+    tick();
+    wizardTestFixture.detectChanges();
+
+    checkWizardState(wizard, 0, true, [0], false);
+
+    // "SA" should become "DESA"
+    expect(navigationSymbolEls.length).toBe(3);
+    expect(navigationSymbolEls[0].nativeElement.textContent.trim()).toBe('DESA');
+    expect(navigationSymbolEls[1].nativeElement.textContent.trim()).toBe('B');
+    expect(navigationSymbolEls[2].nativeElement.textContent.trim()).toBe('C');
+  }));
+
+  it('should change first navigation symbol correctly upon entering the completion step', fakeAsync(() => {
+    const navigationSymbolEls = wizardTestFixture.debugElement.queryAll(By.css('aw-wizard-navigation-bar ul li .step-indicator'));
+
+    // go to second step
+    wizard.goToNextStep();
+    tick();
+    wizardTestFixture.detectChanges();
+
+    // go to third step
+    wizard.goToNextStep();
+    tick();
+    wizardTestFixture.detectChanges();
+
+    checkWizardState(wizard, 2, false, [0, 1, 2], true);
+
+    // "SA" should become "DA"
+    expect(navigationSymbolEls.length).toBe(3);
+    expect(navigationSymbolEls[0].nativeElement.textContent.trim()).toBe('DA');
+    expect(navigationSymbolEls[1].nativeElement.textContent.trim()).toBe('B');
+    expect(navigationSymbolEls[2].nativeElement.textContent.trim()).toBe('C');
+  }));
 });

--- a/src/lib/directives/wizard-step-title.directive.spec.ts
+++ b/src/lib/directives/wizard-step-title.directive.spec.ts
@@ -1,36 +1,45 @@
 import {Component, ViewChild} from '@angular/core';
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {ArchwizardModule} from '../archwizard.module';
 import {WizardComponent} from '../components/wizard.component';
+import {checkWizardState} from '../util/test-utils';
 
 @Component({
   selector: 'aw-test-wizard',
   template: `
     <aw-wizard>
       <aw-wizard-step stepTitle='Not visible title'>
-        <ng-template awStepTitle>
-          Steptitle 1
+        <ng-template awStepTitle let-wizardStep="wizardStep">
+        {{ wizardStep.completed ? 'D' : '' }}{{ wizardStep.editing ? 'E' : '' }}{{ wizardStep.selected ? 'S' : '' }} Steptitle 1
         </ng-template>
         Step 1
       </aw-wizard-step>
-      <aw-wizard-completion-step stepTitle='Other not visible title'>
-        <ng-template awWizardStepTitle>
+      <aw-wizard-step stepTitle='Not visible title'>
+        <ng-template awStepTitle>
           Steptitle 2
         </ng-template>
         Step 2
+      </aw-wizard-step>
+      <aw-wizard-completion-step stepTitle='Other not visible title'>
+        <ng-template awWizardStepTitle>
+          Steptitle 3
+        </ng-template>
+        Step 3
       </aw-wizard-completion-step>
     </aw-wizard>
   `
 })
 class WizardTestComponent {
-  @ViewChild(WizardComponent, {static: false})
+  @ViewChild(WizardComponent, { static: false })
   public wizard: WizardComponent;
 }
 
 describe('WizardStepTitleDirective', () => {
-  let wizardTest: WizardTestComponent;
   let wizardTestFixture: ComponentFixture<WizardTestComponent>;
+
+  let wizardTest: WizardTestComponent;
+  let wizard: WizardComponent;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -44,13 +53,78 @@ describe('WizardStepTitleDirective', () => {
     wizardTestFixture.detectChanges();
 
     wizardTest = wizardTestFixture.componentInstance;
+    wizard = wizardTest.wizard;
   });
 
   it('should create an instance', () => {
     const navigationLinkEls = wizardTestFixture.debugElement.queryAll(By.css('aw-wizard-navigation-bar ul li a'));
 
-    expect(navigationLinkEls.length).toBe(2);
-    expect(navigationLinkEls[0].nativeElement.textContent.trim()).toBe('Steptitle 1');
+    checkWizardState(wizard, 0, false, [], false);
+
+    expect(navigationLinkEls.length).toBe(3);
+    expect(navigationLinkEls[0].nativeElement.textContent.trim()).toBe('S Steptitle 1');
     expect(navigationLinkEls[1].nativeElement.textContent.trim()).toBe('Steptitle 2');
+    expect(navigationLinkEls[2].nativeElement.textContent.trim()).toBe('Steptitle 3');
   });
+
+  it('should change first step title correctly upon completion state change', fakeAsync(() => {
+    const navigationLinkEls = wizardTestFixture.debugElement.queryAll(By.css('aw-wizard-navigation-bar ul li a'));
+
+    // go to second step
+    wizard.goToNextStep();
+    tick();
+    wizardTestFixture.detectChanges();
+
+    checkWizardState(wizard, 1, false, [0], false);
+
+    // "S Steptitle 1" should become "D Steptitle 1"
+    expect(navigationLinkEls.length).toBe(3);
+    expect(navigationLinkEls[0].nativeElement.textContent.trim()).toBe('D Steptitle 1');
+    expect(navigationLinkEls[1].nativeElement.textContent.trim()).toBe('Steptitle 2');
+    expect(navigationLinkEls[2].nativeElement.textContent.trim()).toBe('Steptitle 3');
+  }));
+
+  it('should change first step title correctly upon editing state change', fakeAsync(() => {
+    const navigationLinkEls = wizardTestFixture.debugElement.queryAll(By.css('aw-wizard-navigation-bar ul li a'));
+
+    // go to second step
+    wizard.goToNextStep();
+    tick();
+    wizardTestFixture.detectChanges();
+
+    // go to first step
+    wizard.goToPreviousStep();
+    tick();
+    wizardTestFixture.detectChanges();
+
+    checkWizardState(wizard, 0, true, [0], false);
+
+    // "S Steptitle 1" should become "DES Steptitle 1"
+    expect(navigationLinkEls.length).toBe(3);
+    expect(navigationLinkEls[0].nativeElement.textContent.trim()).toBe('DES Steptitle 1');
+    expect(navigationLinkEls[1].nativeElement.textContent.trim()).toBe('Steptitle 2');
+    expect(navigationLinkEls[2].nativeElement.textContent.trim()).toBe('Steptitle 3');
+  }));
+
+  it('should change first step title correctly upon entering the completion step', fakeAsync(() => {
+    const navigationLinkEls = wizardTestFixture.debugElement.queryAll(By.css('aw-wizard-navigation-bar ul li a'));
+
+    // go to second step
+    wizard.goToNextStep();
+    tick();
+    wizardTestFixture.detectChanges();
+
+    // go to third step
+    wizard.goToNextStep();
+    tick();
+    wizardTestFixture.detectChanges();
+
+    checkWizardState(wizard, 2, false, [0, 1, 2], true);
+
+    // "S Steptitle 1" should become "D Steptitle 1"
+    expect(navigationLinkEls.length).toBe(3);
+    expect(navigationLinkEls[0].nativeElement.textContent.trim()).toBe('D Steptitle 1');
+    expect(navigationLinkEls[1].nativeElement.textContent.trim()).toBe('Steptitle 2');
+    expect(navigationLinkEls[2].nativeElement.textContent.trim()).toBe('Steptitle 3');
+  }));
 });


### PR DESCRIPTION
This PR closes #251

<a href="https://gitpod.io/#https://github.com/madoar/angular-archwizard/pull/253"><img src="https://gitpod.io/api/apps/github/pbs/github.com/madoar/angular-archwizard.git/2c934ca7acb69034c24f1869d56f2f68cdcda027.svg" /></a>

