### PR TITLE
Test on Node 10, 12 and latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,33 +12,33 @@ addons:
 jobs:
   include:
     # Tests
-    - stage: Test 
+    - stage: Test
       os: linux
       dist: trusty
       node_js: "10"
-    - stage: Test 
-      os: linux
-      dist: trusty
-      node_js: "11"
-    - stage: Test 
+    - stage: Test
       os: linux
       dist: trusty
       node_js: "12"
-    - stage: Test 
+    - stage: Test
+      os: linux
+      dist: trusty
+      node_js: "node"
+    - stage: Test
       os: osx
       node_js: "10"
-    - stage: Test 
-      os: osx
-      node_js: "11"
-    - stage: Test 
+    - stage: Test
       os: osx
       node_js: "12"
+    - stage: Test
+      os: osx
+      node_js: "node"
     # Build
     - stage: Build
       os: linux
       node_js: "12"
       addons:
-        chrome: stable    
+        chrome: stable
       script: npm run build
     # Coverage
     - stage: Coverage
@@ -49,4 +49,4 @@ jobs:
       script: npm test
       after_success:
         - npm install -g codacy-coverage
-        - codacy-coverage < coverage/lcov.info    
+        - codacy-coverage < coverage/lcov.info


### PR DESCRIPTION
This PR removes Node 11 from the test setup as it has already reached its EOL and adds Node latest (13 at the moment, fail early).

Generally odd major version numbers should not be tested as these are short living release branches. See https://github.com/nodejs/Release#end-of-life-releases


<a href="https://gitpod.io/#https://github.com/madoar/angular-archwizard/pull/259"><img src="https://gitpod.io/api/apps/github/pbs/github.com/DanielRuf/angular-archwizard.git/3f779275bf67491ff79701796b26f55106c7c0fa.svg" /></a>

