### PR TITLE
Remove unused HostListener arguments

### DIFF
--- a/src/lib/directives/go-to-step.directive.ts
+++ b/src/lib/directives/go-to-step.directive.ts
@@ -118,8 +118,8 @@ export class GoToStepDirective {
    * Listener method for `click` events on the component with this directive.
    * After this method is called the wizard will try to transition to the `destinationStep`
    */
-  @HostListener('click', ['$event'])
-  public onClick(event: Event): void {
+  @HostListener('click')
+  public onClick(): void {
     this.wizard.goToStep(this.destinationStep, this.preFinalize, this.postFinalize);
   }
 }

--- a/src/lib/directives/next-step.directive.ts
+++ b/src/lib/directives/next-step.directive.ts
@@ -58,8 +58,8 @@ export class NextStepDirective {
    * Listener method for `click` events on the component with this directive.
    * After this method is called the wizard will try to transition to the next step
    */
-  @HostListener('click', ['$event'])
-  public onClick(event: Event): void {
+  @HostListener('click')
+  public onClick(): void {
     this.wizard.goToNextStep(this.preFinalize, this.postFinalize);
   }
 }

--- a/src/lib/directives/previous-step.directive.ts
+++ b/src/lib/directives/previous-step.directive.ts
@@ -59,8 +59,8 @@ export class PreviousStepDirective {
    * Listener method for `click` events on the component with this directive.
    * After this method is called the wizard will try to transition to the previous step
    */
-  @HostListener('click', ['$event'])
-  public onClick(event: Event): void {
+  @HostListener('click')
+  public onClick(): void {
     this.wizard.goToPreviousStep(this.preFinalize, this.postFinalize);
   }
 }

--- a/src/lib/directives/reset-wizard.directive.ts
+++ b/src/lib/directives/reset-wizard.directive.ts
@@ -34,8 +34,8 @@ export class ResetWizardDirective {
   /**
    * Resets the wizard
    */
-  @HostListener('click', ['$event'])
-  public onClick(event: Event): void {
+  @HostListener('click')
+  public onClick(): void {
     // do some optional cleanup work
     this.finalize.emit();
     // reset the wizard to its initial state

--- a/src/lib/util/wizard-step.interface.ts
+++ b/src/lib/util/wizard-step.interface.ts
@@ -107,7 +107,7 @@ export abstract class WizardStep {
   public stepExit: EventEmitter<MovingDirection> = new EventEmitter<MovingDirection>();
 
   /**
-   * Returns if this wizard step should be visible to the user.
+   * Returns true if this wizard step should be visible to the user.
    * If the step should be visible to the user false is returned, otherwise true
    */
   @HostBinding('hidden')


### PR DESCRIPTION
This PR:
- removes unused parameters of HostListener functions
- adds a missing wort to a comment

<a href="https://gitpod.io/#https://github.com/madoar/angular-archwizard/pull/267"><img src="https://gitpod.io/api/apps/github/pbs/github.com/madoar/angular-archwizard.git/cbf730f653d59621209b67c8dcde27da10cc42ff.svg" /></a>

