### PR TITLE
Fix the SCSS global variable warnings

### DIFF
--- a/src/css/archwizard.scss
+++ b/src/css/archwizard.scss
@@ -141,6 +141,10 @@ $aw-distance-between-steps: 10px !default;
 
 $aw-text-height: 14px !default;
 
+// declare global variables
+$aw-param-indicator-width: null;
+$aw-param-indicator-height: null;
+$aw-param-indicator-border-width: null;
 
 aw-wizard {
   display: flex;


### PR DESCRIPTION
This PR fixes the warnings: 

```
DEPRECATION WARNING: As of Dart Sass 2.0.0, !global assignments won't be able to
declare new variables. Consider adding `$aw-param-indicator-width: null` at the root of the
stylesheet.

    ╷
273 │   $aw-param-indicator-width: $width !global;
    │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ╵
    stdin 273:3   aw-define-style()
    stdin 393:13  aw-define-styles()
    stdin 600:1   root stylesheet

DEPRECATION WARNING: As of Dart Sass 2.0.0, !global assignments won't be able to
declare new variables. Consider adding `$aw-param-indicator-height: null` at the root of the
stylesheet.

    ╷
274 │   $aw-param-indicator-height: $height !global;
    │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ╵
    stdin 274:3   aw-define-style()
    stdin 393:13  aw-define-styles()
    stdin 600:1   root stylesheet

DEPRECATION WARNING: As of Dart Sass 2.0.0, !global assignments won't be able to
declare new variables. Consider adding `$aw-param-indicator-border-width: null` at the root of the
stylesheet.

    ╷
275 │   $aw-param-indicator-border-width: $border-width !global;
    │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ╵
    stdin 275:3   aw-define-style()
    stdin 393:13  aw-define-styles()
    stdin 600:1   root stylesheet
```

See also https://github.com/madoar/angular-archwizard/pull/268#issuecomment-591062471

<a href="https://gitpod.io/#https://github.com/madoar/angular-archwizard/pull/269"><img src="https://gitpod.io/api/apps/github/pbs/github.com/madoar/angular-archwizard.git/ab2e0c0facca85af760fafa2c3f053d362757a01.svg" /></a>

